### PR TITLE
Implement Home and Menu screens

### DIFF
--- a/src/pages/HomePage.tsx
+++ b/src/pages/HomePage.tsx
@@ -1,0 +1,34 @@
+import { Link } from "react-router-dom";
+
+export default function HomePage() {
+  return (
+    <div className="flex min-h-screen flex-col items-center justify-center bg-gray-50 px-4">
+      <div className="max-w-2xl text-center">
+        <h1 className="text-4xl font-bold tracking-tight text-gray-900 sm:text-5xl">
+          Bienvenido a nuestro restaurante
+        </h1>
+        <p className="mt-4 text-lg text-gray-600">
+          Reserva tu mesa, explora nuestro menu y disfruta de una experiencia
+          gastronomica unica.
+        </p>
+
+        <div className="mt-8 flex flex-col items-center gap-4 sm:flex-row sm:justify-center">
+          <Link
+            to="/reservations/new"
+            className="rounded-md bg-indigo-600 px-6 py-3 text-sm font-medium text-white
+              transition-colors hover:bg-indigo-700"
+          >
+            Reservar mesa
+          </Link>
+          <Link
+            to="/menu"
+            className="rounded-md border border-gray-300 bg-white px-6 py-3 text-sm
+              font-medium text-gray-700 transition-colors hover:bg-gray-50"
+          >
+            Ver menu
+          </Link>
+        </div>
+      </div>
+    </div>
+  );
+}

--- a/src/pages/MenuPage.tsx
+++ b/src/pages/MenuPage.tsx
@@ -1,0 +1,120 @@
+import { useEffect, useState } from "react";
+import type { MenuCategory, MenuItem } from "../types/api";
+import * as menuService from "../services/menu.service";
+
+const CATEGORIES: { value: MenuCategory; label: string }[] = [
+  { value: "entrantes", label: "Entrantes" },
+  { value: "principales", label: "Principales" },
+  { value: "postres", label: "Postres" },
+  { value: "bebidas", label: "Bebidas" },
+];
+
+export default function MenuPage() {
+  const [items, setItems] = useState<MenuItem[]>([]);
+  const [activeCategory, setActiveCategory] = useState<MenuCategory | null>(
+    null,
+  );
+  const [isLoading, setIsLoading] = useState(true);
+  const [error, setError] = useState("");
+
+  useEffect(() => {
+    setIsLoading(true);
+    setError("");
+
+    const category = activeCategory ?? undefined;
+    menuService
+      .getMenuItems(category)
+      .then((response) => setItems(response.data))
+      .catch((err: unknown) => {
+        const message =
+          err instanceof Error ? err.message : "Error al cargar el menu";
+        setError(message);
+      })
+      .finally(() => setIsLoading(false));
+  }, [activeCategory]);
+
+  const groupedItems = activeCategory
+    ? { [activeCategory]: items }
+    : items.reduce<Record<string, MenuItem[]>>((acc, item) => {
+        const group = acc[item.category] ?? [];
+        group.push(item);
+        acc[item.category] = group;
+        return acc;
+      }, {});
+
+  return (
+    <div className="mx-auto max-w-4xl px-4 py-8">
+      <h1 className="text-3xl font-bold text-gray-900">Nuestro menu</h1>
+
+      <div className="mt-6 flex flex-wrap gap-2">
+        <button
+          type="button"
+          onClick={() => setActiveCategory(null)}
+          className={`rounded-full px-4 py-2 text-sm font-medium transition-colors
+            ${!activeCategory
+              ? "bg-indigo-600 text-white"
+              : "bg-gray-100 text-gray-700 hover:bg-gray-200"}`}
+        >
+          Todos
+        </button>
+        {CATEGORIES.map((cat) => (
+          <button
+            key={cat.value}
+            type="button"
+            onClick={() => setActiveCategory(cat.value)}
+            className={`rounded-full px-4 py-2 text-sm font-medium transition-colors
+              ${activeCategory === cat.value
+                ? "bg-indigo-600 text-white"
+                : "bg-gray-100 text-gray-700 hover:bg-gray-200"}`}
+          >
+            {cat.label}
+          </button>
+        ))}
+      </div>
+
+      {isLoading && <p className="mt-8 text-gray-500">Cargando menu...</p>}
+
+      {error && <p className="mt-8 text-red-600">{error}</p>}
+
+      {!isLoading && !error && items.length === 0 && (
+        <p className="mt-8 text-gray-500">No hay items disponibles.</p>
+      )}
+
+      {!isLoading && !error && items.length > 0 && (
+        <div className="mt-8 space-y-10">
+          {CATEGORIES.filter((cat) => groupedItems[cat.value]).map((cat) => (
+            <section key={cat.value}>
+              <h2 className="text-xl font-semibold text-gray-800">
+                {cat.label}
+              </h2>
+              <div className="mt-4 grid gap-4 sm:grid-cols-2">
+                {groupedItems[cat.value].map((item) => (
+                  <div
+                    key={item.id}
+                    className="rounded-lg border border-gray-200 bg-white p-4"
+                  >
+                    <div className="flex items-start justify-between gap-3">
+                      <div>
+                        <h3 className="font-medium text-gray-900">
+                          {item.name}
+                        </h3>
+                        {item.description && (
+                          <p className="mt-1 text-sm text-gray-500">
+                            {item.description}
+                          </p>
+                        )}
+                      </div>
+                      <span className="shrink-0 font-semibold text-indigo-600">
+                        ${item.price}
+                      </span>
+                    </div>
+                  </div>
+                ))}
+              </div>
+            </section>
+          ))}
+        </div>
+      )}
+    </div>
+  );
+}

--- a/src/pages/__tests__/HomePage.test.tsx
+++ b/src/pages/__tests__/HomePage.test.tsx
@@ -1,0 +1,38 @@
+import { render, screen } from "@testing-library/react";
+import { MemoryRouter } from "react-router-dom";
+import HomePage from "../HomePage";
+
+function renderHomePage() {
+  return render(
+    <MemoryRouter>
+      <HomePage />
+    </MemoryRouter>,
+  );
+}
+
+describe("HomePage", () => {
+  it("renders the welcome heading", () => {
+    renderHomePage();
+
+    expect(
+      screen.getByRole("heading", {
+        name: "Bienvenido a nuestro restaurante",
+      }),
+    ).toBeInTheDocument();
+  });
+
+  it("renders CTA link to reserve", () => {
+    renderHomePage();
+
+    expect(screen.getByText("Reservar mesa")).toHaveAttribute(
+      "href",
+      "/reservations/new",
+    );
+  });
+
+  it("renders CTA link to menu", () => {
+    renderHomePage();
+
+    expect(screen.getByText("Ver menu")).toHaveAttribute("href", "/menu");
+  });
+});

--- a/src/pages/__tests__/MenuPage.test.tsx
+++ b/src/pages/__tests__/MenuPage.test.tsx
@@ -1,0 +1,167 @@
+import { render, screen, waitFor } from "@testing-library/react";
+import userEvent from "@testing-library/user-event";
+import MenuPage from "../MenuPage";
+import * as menuService from "../../services/menu.service";
+import type { MenuItem, PaginatedResponse } from "../../types/api";
+
+vi.mock("../../services/menu.service");
+
+const MOCK_ITEMS: MenuItem[] = [
+  {
+    id: 1,
+    name: "Bruschetta",
+    description: "Pan tostado con tomate",
+    price: "8.50",
+    category: "entrantes",
+    is_available: true,
+    daily_stock: null,
+    created_at: "2026-01-01",
+  },
+  {
+    id: 2,
+    name: "Risotto",
+    description: null,
+    price: "18.00",
+    category: "principales",
+    is_available: true,
+    daily_stock: 10,
+    created_at: "2026-01-01",
+  },
+  {
+    id: 3,
+    name: "Tiramisu",
+    description: "Postre italiano clasico",
+    price: "9.00",
+    category: "postres",
+    is_available: true,
+    daily_stock: null,
+    created_at: "2026-01-01",
+  },
+];
+
+function mockGetMenuItems(items: MenuItem[] = MOCK_ITEMS) {
+  const response: PaginatedResponse<MenuItem> = {
+    data: items,
+    meta: { current_page: 1, last_page: 1, per_page: 15, total: items.length },
+  };
+  vi.mocked(menuService.getMenuItems).mockResolvedValue(response);
+}
+
+describe("MenuPage", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it("shows loading state initially", () => {
+    vi.mocked(menuService.getMenuItems).mockReturnValue(
+      new Promise(() => {}),
+    );
+    render(<MenuPage />);
+
+    expect(screen.getByText("Cargando menu...")).toBeInTheDocument();
+  });
+
+  it("renders items grouped by category", async () => {
+    mockGetMenuItems();
+    render(<MenuPage />);
+
+    await waitFor(() => {
+      expect(screen.getByText("Bruschetta")).toBeInTheDocument();
+    });
+
+    expect(
+      screen.getByRole("heading", { name: "Entrantes" }),
+    ).toBeInTheDocument();
+    expect(
+      screen.getByRole("heading", { name: "Principales" }),
+    ).toBeInTheDocument();
+    expect(
+      screen.getByRole("heading", { name: "Postres" }),
+    ).toBeInTheDocument();
+    expect(screen.getByText("Risotto")).toBeInTheDocument();
+    expect(screen.getByText("Tiramisu")).toBeInTheDocument();
+  });
+
+  it("shows item description when available", async () => {
+    mockGetMenuItems();
+    render(<MenuPage />);
+
+    await waitFor(() => {
+      expect(screen.getByText("Pan tostado con tomate")).toBeInTheDocument();
+    });
+  });
+
+  it("shows item price", async () => {
+    mockGetMenuItems();
+    render(<MenuPage />);
+
+    await waitFor(() => {
+      expect(screen.getByText("$8.50")).toBeInTheDocument();
+    });
+  });
+
+  it("filters by category when a tab is clicked", async () => {
+    mockGetMenuItems();
+    render(<MenuPage />);
+    const user = userEvent.setup();
+
+    await waitFor(() => {
+      expect(screen.getByText("Bruschetta")).toBeInTheDocument();
+    });
+
+    const entreesOnly: MenuItem[] = [MOCK_ITEMS[0]];
+    mockGetMenuItems(entreesOnly);
+
+    await user.click(screen.getByRole("button", { name: "Entrantes" }));
+
+    await waitFor(() => {
+      expect(menuService.getMenuItems).toHaveBeenLastCalledWith("entrantes");
+    });
+  });
+
+  it("shows all items when Todos tab is clicked after filtering", async () => {
+    mockGetMenuItems();
+    render(<MenuPage />);
+    const user = userEvent.setup();
+
+    await waitFor(() => {
+      expect(screen.getByText("Bruschetta")).toBeInTheDocument();
+    });
+
+    mockGetMenuItems([MOCK_ITEMS[0]]);
+    await user.click(screen.getByRole("button", { name: "Entrantes" }));
+
+    await waitFor(() => {
+      expect(menuService.getMenuItems).toHaveBeenLastCalledWith("entrantes");
+    });
+
+    mockGetMenuItems();
+    await user.click(screen.getByRole("button", { name: "Todos" }));
+
+    await waitFor(() => {
+      expect(menuService.getMenuItems).toHaveBeenLastCalledWith(undefined);
+    });
+  });
+
+  it("shows error message when fetch fails", async () => {
+    vi.mocked(menuService.getMenuItems).mockRejectedValue(
+      new Error("Error del servidor"),
+    );
+    render(<MenuPage />);
+
+    await waitFor(() => {
+      expect(screen.getByText("Error del servidor")).toBeInTheDocument();
+    });
+  });
+
+  it("shows empty state when no items are returned", async () => {
+    mockGetMenuItems([]);
+    render(<MenuPage />);
+
+    await waitFor(() => {
+      expect(
+        screen.getByText("No hay items disponibles."),
+      ).toBeInTheDocument();
+    });
+  });
+});

--- a/src/routes/Router.tsx
+++ b/src/routes/Router.tsx
@@ -3,10 +3,12 @@ import { AuthProvider } from "../context/AuthContext";
 import Layout from "../components/Layout";
 import GuestRoute from "./GuestRoute";
 import ProtectedRoute from "./ProtectedRoute";
+import HomePage from "../pages/HomePage";
 import LoginPage from "../pages/LoginPage";
 import RegisterPage from "../pages/RegisterPage";
 import ForgotPasswordPage from "../pages/ForgotPasswordPage";
 import ResetPasswordPage from "../pages/ResetPasswordPage";
+import MenuPage from "../pages/MenuPage";
 
 // Placeholder components until real pages are built
 function Placeholder({ name }: { name: string }) {
@@ -20,7 +22,7 @@ export default function Router() {
         <Routes>
           <Route element={<Layout />}>
             {/* Public routes */}
-            <Route path="/" element={<Placeholder name="Home" />} />
+            <Route path="/" element={<HomePage />} />
             <Route element={<GuestRoute />}>
               <Route path="/login" element={<LoginPage />} />
               <Route path="/register" element={<RegisterPage />} />
@@ -33,7 +35,7 @@ export default function Router() {
                 element={<ResetPasswordPage />}
               />
             </Route>
-            <Route path="/menu" element={<Placeholder name="Menu" />} />
+            <Route path="/menu" element={<MenuPage />} />
             <Route
               path="/reservations/new"
               element={<Placeholder name="New Reservation" />}


### PR DESCRIPTION
## Summary

- Add Home landing page with hero section and CTA buttons to reserve and view menu
- Add Menu page that fetches items from the API, groups by category, and supports tab filtering
- Menu includes loading, error, and empty states
- Replace Home and Menu placeholders in Router with real pages

## Test plan

- [x] HomePage: renders welcome heading, CTA link to reserve, CTA link to menu
- [x] MenuPage: loading state, items grouped by category, item description and price displayed, category filter calls API with correct param, Todos tab resets filter, error state, empty state
- [x] 31 total tests passing, TypeScript compiles with no errors

Closes #5