### PR TITLE
Implement New Reservation screen with table selection

### DIFF
--- a/src/pages/NewReservationPage.tsx
+++ b/src/pages/NewReservationPage.tsx
@@ -1,0 +1,410 @@
+import { useState } from "react";
+import { useForm } from "react-hook-form";
+import { useNavigate } from "react-router-dom";
+import FormField from "../components/FormField";
+import SubmitButton from "../components/SubmitButton";
+import { useAuth } from "../context/AuthContext";
+import { handleApiError } from "../lib/form-errors";
+import type { Table } from "../types/api";
+import * as reservationService from "../services/reservation.service";
+import * as guestService from "../services/guest.service";
+
+function formatDate(date: Date): string {
+  const year = date.getFullYear();
+  const month = String(date.getMonth() + 1).padStart(2, "0");
+  const day = String(date.getDate()).padStart(2, "0");
+  return `${year}-${month}-${day}`;
+}
+
+function generateTimeSlots(): string[] {
+  const slots: string[] = [];
+  for (let hour = 12; hour <= 22; hour++) {
+    slots.push(`${String(hour).padStart(2, "0")}:00`);
+    if (hour < 22) {
+      slots.push(`${String(hour).padStart(2, "0")}:30`);
+    }
+  }
+  return slots;
+}
+
+const TIME_SLOTS = generateTimeSlots();
+
+interface GuestForm {
+  name: string;
+  email: string;
+  phone: string;
+}
+
+const GUEST_FIELDS: (keyof GuestForm)[] = ["name", "email", "phone"];
+
+const STEP_LABELS = ["Buscar", "Elegir mesa", "Confirmar"];
+
+export default function NewReservationPage() {
+  const { isAuthenticated } = useAuth();
+  const navigate = useNavigate();
+
+  const today = new Date();
+  const maxDate = new Date(today);
+  maxDate.setDate(today.getDate() + 7);
+  const minDateStr = formatDate(today);
+  const maxDateStr = formatDate(maxDate);
+
+  const [step, setStep] = useState(1);
+  const [date, setDate] = useState("");
+  const [startTime, setStartTime] = useState("");
+  const [seatsRequested, setSeatsRequested] = useState("");
+  const [tables, setTables] = useState<Table[]>([]);
+  const [selectedTable, setSelectedTable] = useState<Table | null>(null);
+  const [isLoading, setIsLoading] = useState(false);
+  const [isHoldSubmitting, setIsHoldSubmitting] = useState(false);
+  const [error, setError] = useState("");
+
+  const {
+    register,
+    handleSubmit: handleGuestSubmit,
+    setError: setGuestError,
+    formState: { errors: guestErrors, isSubmitting: isGuestSubmitting },
+  } = useForm<GuestForm>();
+
+  const searchTables = async () => {
+    setIsLoading(true);
+    setError("");
+
+    try {
+      const response = await reservationService.getAvailableTables({
+        date,
+        start_time: startTime,
+        seats_requested: Number(seatsRequested),
+      });
+
+      if (response.data.length === 0) {
+        setError("No hay mesas disponibles para los criterios seleccionados.");
+        return;
+      }
+
+      setTables(response.data);
+      setStep(2);
+    } catch (err: unknown) {
+      const message =
+        err instanceof Error ? err.message : "Error al buscar mesas";
+      setError(message);
+    } finally {
+      setIsLoading(false);
+    }
+  };
+
+  const navigateToPayment = (
+    clientSecret: string,
+    reservationId: number,
+  ) => {
+    navigate("/payment", { state: { clientSecret, reservationId } });
+  };
+
+  const createRegisteredHold = async () => {
+    if (!selectedTable) return;
+    setIsHoldSubmitting(true);
+    setError("");
+
+    try {
+      const response = await reservationService.createHold({
+        table_id: selectedTable.id,
+        seats_requested: Number(seatsRequested),
+        date,
+        start_time: startTime,
+      });
+      navigateToPayment(
+        response.data.payment_intent_client_secret,
+        response.data.reservation.id,
+      );
+    } catch (err: unknown) {
+      const message =
+        err instanceof Error
+          ? err.message
+          : "Error al crear la reservacion";
+      setError(message);
+    } finally {
+      setIsHoldSubmitting(false);
+    }
+  };
+
+  const createGuestHold = async (guestData: GuestForm) => {
+    if (!selectedTable) return;
+
+    try {
+      const response = await guestService.createGuestReservation({
+        ...guestData,
+        table_id: selectedTable.id,
+        seats_requested: Number(seatsRequested),
+        date,
+        start_time: startTime,
+      });
+      navigateToPayment(
+        response.data.payment_intent_client_secret,
+        response.data.reservation.id,
+      );
+    } catch (err) {
+      handleApiError<GuestForm>(err, setGuestError, GUEST_FIELDS);
+    }
+  };
+
+  return (
+    <div className="mx-auto max-w-2xl px-4 py-8">
+      <h1 className="text-3xl font-bold text-gray-900">Nueva reservacion</h1>
+
+      <div className="mt-4 flex gap-2 text-sm">
+        {STEP_LABELS.map((label, i) => (
+          <span
+            key={label}
+            className={`rounded-full px-3 py-1 ${
+              step === i + 1
+                ? "bg-indigo-600 text-white"
+                : "bg-gray-100 text-gray-500"
+            }`}
+          >
+            {label}
+          </span>
+        ))}
+      </div>
+
+      {error && (
+        <p className="mt-4 rounded-md bg-red-50 p-3 text-sm text-red-600">
+          {error}
+        </p>
+      )}
+
+      {step === 1 && (
+        <form
+          onSubmit={(e) => {
+            e.preventDefault();
+            searchTables();
+          }}
+          className="mt-6 flex flex-col gap-4"
+        >
+          <div className="flex flex-col gap-1">
+            <label
+              htmlFor="date"
+              className="text-sm font-medium text-gray-700"
+            >
+              Fecha
+            </label>
+            <input
+              id="date"
+              type="date"
+              min={minDateStr}
+              max={maxDateStr}
+              value={date}
+              onChange={(e) => setDate(e.target.value)}
+              required
+              className="rounded-md border border-gray-300 px-3 py-2 text-sm outline-none
+                transition-colors focus:ring-2 focus:ring-indigo-500"
+            />
+          </div>
+
+          <div className="flex flex-col gap-1">
+            <label
+              htmlFor="start_time"
+              className="text-sm font-medium text-gray-700"
+            >
+              Hora
+            </label>
+            <select
+              id="start_time"
+              value={startTime}
+              onChange={(e) => setStartTime(e.target.value)}
+              required
+              className="rounded-md border border-gray-300 px-3 py-2 text-sm outline-none
+                transition-colors focus:ring-2 focus:ring-indigo-500"
+            >
+              <option value="">Selecciona una hora</option>
+              {TIME_SLOTS.map((slot) => (
+                <option key={slot} value={slot}>
+                  {slot}
+                </option>
+              ))}
+            </select>
+          </div>
+
+          <div className="flex flex-col gap-1">
+            <label
+              htmlFor="seats"
+              className="text-sm font-medium text-gray-700"
+            >
+              Personas
+            </label>
+            <input
+              id="seats"
+              type="number"
+              min="1"
+              value={seatsRequested}
+              onChange={(e) => setSeatsRequested(e.target.value)}
+              required
+              className="rounded-md border border-gray-300 px-3 py-2 text-sm outline-none
+                transition-colors focus:ring-2 focus:ring-indigo-500"
+            />
+          </div>
+
+          <button
+            type="submit"
+            disabled={isLoading}
+            className="rounded-md bg-indigo-600 py-2 text-sm font-medium text-white
+              transition-colors hover:bg-indigo-700
+              disabled:cursor-not-allowed disabled:opacity-50"
+          >
+            {isLoading ? "Buscando..." : "Buscar mesas disponibles"}
+          </button>
+        </form>
+      )}
+
+      {step === 2 && (
+        <div className="mt-6">
+          <p className="text-sm text-gray-600">
+            {tables.length}{" "}
+            {tables.length === 1 ? "mesa disponible" : "mesas disponibles"}{" "}
+            para {date} a las {startTime}
+          </p>
+
+          <div className="mt-4 grid gap-3">
+            {tables.map((table) => (
+              <button
+                key={table.id}
+                type="button"
+                onClick={() => setSelectedTable(table)}
+                className={`rounded-lg border p-4 text-left transition-colors ${
+                  selectedTable?.id === table.id
+                    ? "border-indigo-600 bg-indigo-50 ring-2 ring-indigo-500"
+                    : "border-gray-200 bg-white hover:border-gray-300"
+                }`}
+              >
+                <p className="font-medium text-gray-900">{table.name}</p>
+                <p className="mt-1 text-sm text-gray-500">
+                  {table.min_capacity}-{table.max_capacity} personas ·{" "}
+                  {table.location}
+                </p>
+              </button>
+            ))}
+          </div>
+
+          <div className="mt-6 flex gap-3">
+            <button
+              type="button"
+              onClick={() => {
+                setStep(1);
+                setSelectedTable(null);
+                setError("");
+              }}
+              className="rounded-md border border-gray-300 bg-white px-4 py-2 text-sm
+                font-medium text-gray-700 transition-colors hover:bg-gray-50"
+            >
+              Volver
+            </button>
+            <button
+              type="button"
+              onClick={() => setStep(3)}
+              disabled={!selectedTable}
+              className="rounded-md bg-indigo-600 px-4 py-2 text-sm font-medium text-white
+                transition-colors hover:bg-indigo-700
+                disabled:cursor-not-allowed disabled:opacity-50"
+            >
+              Continuar
+            </button>
+          </div>
+        </div>
+      )}
+
+      {step === 3 && selectedTable && (
+        <div className="mt-6">
+          <div className="rounded-lg border border-gray-200 bg-gray-50 p-4">
+            <h2 className="font-medium text-gray-900">Resumen</h2>
+            <dl className="mt-2 space-y-1 text-sm text-gray-600">
+              <div className="flex justify-between">
+                <dt>Fecha</dt>
+                <dd>{date}</dd>
+              </div>
+              <div className="flex justify-between">
+                <dt>Hora</dt>
+                <dd>{startTime}</dd>
+              </div>
+              <div className="flex justify-between">
+                <dt>Personas</dt>
+                <dd>{seatsRequested}</dd>
+              </div>
+              <div className="flex justify-between">
+                <dt>Mesa</dt>
+                <dd>{selectedTable.name}</dd>
+              </div>
+            </dl>
+          </div>
+
+          {isAuthenticated ? (
+            <button
+              type="button"
+              onClick={createRegisteredHold}
+              disabled={isHoldSubmitting}
+              className="mt-6 w-full rounded-md bg-indigo-600 py-2 text-sm font-medium
+                text-white transition-colors hover:bg-indigo-700
+                disabled:cursor-not-allowed disabled:opacity-50"
+            >
+              {isHoldSubmitting ? "Reservando..." : "Reservar"}
+            </button>
+          ) : (
+            <form
+              onSubmit={handleGuestSubmit(createGuestHold)}
+              className="mt-6 flex flex-col gap-4"
+            >
+              <p className="text-sm text-gray-600">
+                Ingresa tus datos para continuar con la reservacion.
+              </p>
+
+              {guestErrors.root?.message && (
+                <p className="rounded-md bg-red-50 p-3 text-sm text-red-600">
+                  {guestErrors.root.message}
+                </p>
+              )}
+
+              <FormField<GuestForm>
+                label="Nombre"
+                name="name"
+                register={register}
+                errors={guestErrors}
+              />
+
+              <FormField<GuestForm>
+                label="Correo electronico"
+                name="email"
+                type="email"
+                register={register}
+                errors={guestErrors}
+              />
+
+              <FormField<GuestForm>
+                label="Telefono"
+                name="phone"
+                type="tel"
+                register={register}
+                errors={guestErrors}
+              />
+
+              <SubmitButton
+                label="Reservar"
+                loadingLabel="Reservando..."
+                isSubmitting={isGuestSubmitting}
+              />
+            </form>
+          )}
+
+          <button
+            type="button"
+            onClick={() => {
+              setStep(2);
+              setError("");
+            }}
+            className="mt-3 w-full rounded-md border border-gray-300 bg-white py-2 text-sm
+              font-medium text-gray-700 transition-colors hover:bg-gray-50"
+          >
+            Volver
+          </button>
+        </div>
+      )}
+    </div>
+  );
+}

--- a/src/pages/__tests__/NewReservationPage.test.tsx
+++ b/src/pages/__tests__/NewReservationPage.test.tsx
@@ -1,0 +1,361 @@
+import { render, screen, waitFor } from "@testing-library/react";
+import userEvent from "@testing-library/user-event";
+import { MemoryRouter } from "react-router-dom";
+import NewReservationPage from "../NewReservationPage";
+import * as reservationService from "../../services/reservation.service";
+import * as guestService from "../../services/guest.service";
+import { ApiValidationError } from "../../lib/api";
+import type { Table } from "../../types/api";
+
+vi.mock("../../services/reservation.service");
+vi.mock("../../services/guest.service");
+
+const mockNavigate = vi.fn();
+
+vi.mock("react-router-dom", async () => {
+  const actual = await vi.importActual("react-router-dom");
+  return { ...actual, useNavigate: () => mockNavigate };
+});
+
+let mockIsAuthenticated = false;
+
+vi.mock("../../context/AuthContext", () => ({
+  useAuth: () => ({
+    user: mockIsAuthenticated ? { id: 1, name: "Test", email: "t@t.com", role: "client" } : null,
+    isAuthenticated: mockIsAuthenticated,
+    login: vi.fn(),
+    register: vi.fn(),
+    logout: vi.fn(),
+    setSession: vi.fn(),
+  }),
+}));
+
+const MOCK_TABLES: Table[] = [
+  {
+    id: 1,
+    name: "Mesa 1",
+    min_capacity: 2,
+    max_capacity: 4,
+    location: "Interior",
+    description: null,
+    is_active: true,
+    created_at: "2026-01-01",
+  },
+  {
+    id: 2,
+    name: "Mesa 2",
+    min_capacity: 4,
+    max_capacity: 8,
+    location: "Terraza",
+    description: null,
+    is_active: true,
+    created_at: "2026-01-01",
+  },
+];
+
+function mockAvailableTables(tables: Table[] = MOCK_TABLES) {
+  vi.mocked(reservationService.getAvailableTables).mockResolvedValue({
+    data: tables,
+  });
+}
+
+function mockCreateHold() {
+  vi.mocked(reservationService.createHold).mockResolvedValue({
+    data: {
+      reservation: { id: 10 } as never,
+      payment_intent_client_secret: "pi_secret_123",
+    },
+  });
+}
+
+function mockCreateGuestReservation() {
+  vi.mocked(guestService.createGuestReservation).mockResolvedValue({
+    data: {
+      reservation: { id: 11 } as never,
+      payment_intent_client_secret: "pi_secret_456",
+    },
+  });
+}
+
+function renderPage() {
+  return render(
+    <MemoryRouter>
+      <NewReservationPage />
+    </MemoryRouter>,
+  );
+}
+
+async function fillSearchAndSubmit(user: ReturnType<typeof userEvent.setup>) {
+  await user.type(screen.getByLabelText("Fecha"), "2026-04-10");
+  await user.selectOptions(screen.getByLabelText("Hora"), "19:00");
+  await user.clear(screen.getByLabelText("Personas"));
+  await user.type(screen.getByLabelText("Personas"), "4");
+  await user.click(
+    screen.getByRole("button", { name: "Buscar mesas disponibles" }),
+  );
+}
+
+describe("NewReservationPage", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    mockIsAuthenticated = false;
+  });
+
+  describe("Step 1 - Search", () => {
+    it("renders search form with date, time, and seats fields", () => {
+      renderPage();
+
+      expect(screen.getByLabelText("Fecha")).toBeInTheDocument();
+      expect(screen.getByLabelText("Hora")).toBeInTheDocument();
+      expect(screen.getByLabelText("Personas")).toBeInTheDocument();
+      expect(
+        screen.getByRole("button", { name: "Buscar mesas disponibles" }),
+      ).toBeInTheDocument();
+    });
+
+    it("renders step indicators", () => {
+      renderPage();
+
+      expect(screen.getByText("Buscar")).toBeInTheDocument();
+      expect(screen.getByText("Elegir mesa")).toBeInTheDocument();
+      expect(screen.getByText("Confirmar")).toBeInTheDocument();
+    });
+
+    it("calls getAvailableTables and moves to step 2", async () => {
+      mockAvailableTables();
+      renderPage();
+      const user = userEvent.setup();
+
+      await fillSearchAndSubmit(user);
+
+      await waitFor(() => {
+        expect(
+          reservationService.getAvailableTables,
+        ).toHaveBeenCalledWith({
+          date: "2026-04-10",
+          start_time: "19:00",
+          seats_requested: 4,
+        });
+      });
+
+      expect(screen.getByText("Mesa 1")).toBeInTheDocument();
+      expect(screen.getByText("Mesa 2")).toBeInTheDocument();
+    });
+
+    it("shows error when no tables are available", async () => {
+      mockAvailableTables([]);
+      renderPage();
+      const user = userEvent.setup();
+
+      await fillSearchAndSubmit(user);
+
+      await waitFor(() => {
+        expect(
+          screen.getByText(
+            "No hay mesas disponibles para los criterios seleccionados.",
+          ),
+        ).toBeInTheDocument();
+      });
+    });
+
+    it("shows error when API call fails", async () => {
+      vi.mocked(reservationService.getAvailableTables).mockRejectedValue(
+        new Error("Error del servidor"),
+      );
+      renderPage();
+      const user = userEvent.setup();
+
+      await fillSearchAndSubmit(user);
+
+      await waitFor(() => {
+        expect(screen.getByText("Error del servidor")).toBeInTheDocument();
+      });
+    });
+  });
+
+  describe("Step 2 - Table selection", () => {
+    async function goToStep2() {
+      mockAvailableTables();
+      renderPage();
+      const user = userEvent.setup();
+      await fillSearchAndSubmit(user);
+      await waitFor(() => {
+        expect(screen.getByText("Mesa 1")).toBeInTheDocument();
+      });
+      return user;
+    }
+
+    it("displays table count and details", async () => {
+      await goToStep2();
+
+      expect(screen.getByText(/2 mesas disponibles/)).toBeInTheDocument();
+      expect(screen.getByText("2-4 personas · Interior")).toBeInTheDocument();
+      expect(screen.getByText("4-8 personas · Terraza")).toBeInTheDocument();
+    });
+
+    it("allows selecting a table and continuing", async () => {
+      const user = await goToStep2();
+
+      await user.click(screen.getByText("Mesa 1"));
+      await user.click(screen.getByRole("button", { name: "Continuar" }));
+
+      expect(
+        screen.getByRole("heading", { name: "Resumen" }),
+      ).toBeInTheDocument();
+      expect(screen.getByText("Mesa 1")).toBeInTheDocument();
+    });
+
+    it("disables continue button when no table selected", async () => {
+      await goToStep2();
+
+      expect(
+        screen.getByRole("button", { name: "Continuar" }),
+      ).toBeDisabled();
+    });
+
+    it("goes back to step 1 when Volver is clicked", async () => {
+      const user = await goToStep2();
+
+      await user.click(screen.getByRole("button", { name: "Volver" }));
+
+      expect(screen.getByLabelText("Fecha")).toBeInTheDocument();
+    });
+  });
+
+  describe("Step 3 - Registered user hold", () => {
+    async function goToStep3Registered() {
+      mockIsAuthenticated = true;
+      mockAvailableTables();
+      renderPage();
+      const user = userEvent.setup();
+
+      await fillSearchAndSubmit(user);
+      await waitFor(() => {
+        expect(screen.getByText("Mesa 1")).toBeInTheDocument();
+      });
+
+      await user.click(screen.getByText("Mesa 1"));
+      await user.click(screen.getByRole("button", { name: "Continuar" }));
+
+      await waitFor(() => {
+        expect(
+          screen.getByRole("heading", { name: "Resumen" }),
+        ).toBeInTheDocument();
+      });
+
+      return user;
+    }
+
+    it("shows summary and reserve button for authenticated user", async () => {
+      await goToStep3Registered();
+
+      expect(screen.getByText("Mesa 1")).toBeInTheDocument();
+      expect(
+        screen.getByRole("button", { name: "Reservar" }),
+      ).toBeInTheDocument();
+      expect(screen.queryByLabelText("Nombre")).not.toBeInTheDocument();
+    });
+
+    it("creates hold and navigates to payment", async () => {
+      mockCreateHold();
+      const user = await goToStep3Registered();
+
+      await user.click(screen.getByRole("button", { name: "Reservar" }));
+
+      await waitFor(() => {
+        expect(reservationService.createHold).toHaveBeenCalled();
+        expect(mockNavigate).toHaveBeenCalledWith("/payment", {
+          state: { clientSecret: "pi_secret_123", reservationId: 10 },
+        });
+      });
+    });
+
+    it("shows error when hold creation fails", async () => {
+      vi.mocked(reservationService.createHold).mockRejectedValue(
+        new Error("Ya tienes una reservacion pendiente"),
+      );
+      const user = await goToStep3Registered();
+
+      await user.click(screen.getByRole("button", { name: "Reservar" }));
+
+      await waitFor(() => {
+        expect(
+          screen.getByText("Ya tienes una reservacion pendiente"),
+        ).toBeInTheDocument();
+      });
+    });
+  });
+
+  describe("Step 3 - Guest hold", () => {
+    async function goToStep3Guest() {
+      mockIsAuthenticated = false;
+      mockAvailableTables();
+      renderPage();
+      const user = userEvent.setup();
+
+      await fillSearchAndSubmit(user);
+      await waitFor(() => {
+        expect(screen.getByText("Mesa 1")).toBeInTheDocument();
+      });
+
+      await user.click(screen.getByText("Mesa 1"));
+      await user.click(screen.getByRole("button", { name: "Continuar" }));
+
+      await waitFor(() => {
+        expect(
+          screen.getByRole("heading", { name: "Resumen" }),
+        ).toBeInTheDocument();
+      });
+
+      return user;
+    }
+
+    it("shows guest form for unauthenticated user", async () => {
+      await goToStep3Guest();
+
+      expect(screen.getByLabelText("Nombre")).toBeInTheDocument();
+      expect(
+        screen.getByLabelText("Correo electronico"),
+      ).toBeInTheDocument();
+      expect(screen.getByLabelText("Telefono")).toBeInTheDocument();
+    });
+
+    it("creates guest hold and navigates to payment", async () => {
+      mockCreateGuestReservation();
+      const user = await goToStep3Guest();
+
+      await user.type(screen.getByLabelText("Nombre"), "Juan Perez");
+      await user.type(
+        screen.getByLabelText("Correo electronico"),
+        "juan@email.com",
+      );
+      await user.type(screen.getByLabelText("Telefono"), "1234567890");
+      await user.click(screen.getByRole("button", { name: "Reservar" }));
+
+      await waitFor(() => {
+        expect(guestService.createGuestReservation).toHaveBeenCalled();
+        expect(mockNavigate).toHaveBeenCalledWith("/payment", {
+          state: { clientSecret: "pi_secret_456", reservationId: 11 },
+        });
+      });
+    });
+
+    it("displays field errors on 422 validation error", async () => {
+      vi.mocked(guestService.createGuestReservation).mockRejectedValue(
+        new ApiValidationError({
+          message: "Validation failed",
+          errors: { email: ["El correo ya esta registrado"] },
+        }),
+      );
+      const user = await goToStep3Guest();
+
+      await user.click(screen.getByRole("button", { name: "Reservar" }));
+
+      await waitFor(() => {
+        expect(
+          screen.getByText("El correo ya esta registrado"),
+        ).toBeInTheDocument();
+      });
+    });
+  });
+});

--- a/src/routes/Router.tsx
+++ b/src/routes/Router.tsx
@@ -9,6 +9,7 @@ import RegisterPage from "../pages/RegisterPage";
 import ForgotPasswordPage from "../pages/ForgotPasswordPage";
 import ResetPasswordPage from "../pages/ResetPasswordPage";
 import MenuPage from "../pages/MenuPage";
+import NewReservationPage from "../pages/NewReservationPage";
 
 // Placeholder components until real pages are built
 function Placeholder({ name }: { name: string }) {
@@ -38,7 +39,7 @@ export default function Router() {
             <Route path="/menu" element={<MenuPage />} />
             <Route
               path="/reservations/new"
-              element={<Placeholder name="New Reservation" />}
+              element={<NewReservationPage />}
             />
             <Route
               path="/payment"


### PR DESCRIPTION
## Summary

- Add 3-step New Reservation page: search by date/time/seats, select a table, confirm hold
- Step 1: date picker (restricted to 1 week ahead), time select (30-min slots), seats input
- Step 2: available tables displayed as selectable cards with capacity and location
- Step 3 (registered user): summary and confirm button, calls `reservationService.createHold`
- Step 3 (guest): summary + name/email/phone form with RHF, calls `guestService.createGuestReservation`
- On success, navigates to `/payment` with `clientSecret` and `reservationId` via route state
- Replace New Reservation placeholder in Router

## Test plan

- [x] Step 1: renders search form, calls API with correct params, shows error when no tables available, shows error on API failure
- [x] Step 2: displays table count and details, allows selecting and continuing, disables continue without selection, back button returns to step 1
- [x] Step 3 (registered): shows summary without guest form, creates hold and navigates to payment, shows error on failure
- [x] Step 3 (guest): shows guest form, creates guest hold and navigates to payment, displays 422 field errors
- [x] 46 total tests passing, TypeScript compiles with no errors

Closes #7