### PR TITLE
Payment screen with Stripe Elements

### DIFF
--- a/src/pages/NewReservationPage.tsx
+++ b/src/pages/NewReservationPage.tsx
@@ -5,7 +5,7 @@ import FormField from "../components/FormField";
 import SubmitButton from "../components/SubmitButton";
 import { useAuth } from "../context/AuthContext";
 import { handleApiError } from "../lib/form-errors";
-import type { Table } from "../types/api";
+import type { Reservation, Table } from "../types/api";
 import * as reservationService from "../services/reservation.service";
 import * as guestService from "../services/guest.service";
 
@@ -95,9 +95,9 @@ export default function NewReservationPage() {
 
   const navigateToPayment = (
     clientSecret: string,
-    reservationId: number,
+    reservation: Reservation,
   ) => {
-    navigate("/payment", { state: { clientSecret, reservationId } });
+    navigate("/payment", { state: { clientSecret, reservation } });
   };
 
   const createRegisteredHold = async () => {
@@ -114,7 +114,7 @@ export default function NewReservationPage() {
       });
       navigateToPayment(
         response.data.payment_intent_client_secret,
-        response.data.reservation.id,
+        response.data.reservation,
       );
     } catch (err: unknown) {
       const message =
@@ -140,7 +140,7 @@ export default function NewReservationPage() {
       });
       navigateToPayment(
         response.data.payment_intent_client_secret,
-        response.data.reservation.id,
+        response.data.reservation,
       );
     } catch (err) {
       handleApiError<GuestForm>(err, setGuestError, GUEST_FIELDS);

--- a/src/pages/PaymentPage.tsx
+++ b/src/pages/PaymentPage.tsx
@@ -1,0 +1,175 @@
+import { useState } from "react";
+import { Navigate, useLocation, useNavigate, Link } from "react-router-dom";
+import { Elements, PaymentElement, useStripe, useElements } from "@stripe/react-stripe-js";
+import { stripePromise } from "../lib/stripe";
+import { useAuth } from "../context/AuthContext";
+import type { Reservation } from "../types/api";
+
+interface PaymentRouteState {
+  clientSecret: string;
+  reservation: Reservation;
+}
+
+interface CheckoutFormProps {
+  reservation: Reservation;
+}
+
+function isExpired(expiresAt: string | undefined): boolean {
+  if (!expiresAt) return false;
+  return new Date(expiresAt) < new Date();
+}
+
+function formatCurrency(amount: string): string {
+  return `$${Number(amount).toFixed(2)}`;
+}
+
+function CheckoutForm({ reservation }: CheckoutFormProps) {
+  const stripe = useStripe();
+  const elements = useElements();
+  const navigate = useNavigate();
+  const { isAuthenticated } = useAuth();
+
+  const [isProcessing, setIsProcessing] = useState(false);
+  const [error, setError] = useState("");
+  const [isComplete, setIsComplete] = useState(false);
+
+  if (isExpired(reservation.expires_at)) {
+    return (
+      <div className="mx-auto max-w-2xl px-4 py-8">
+        <h1 className="text-3xl font-bold text-gray-900">Pago</h1>
+        <div className="mt-6 rounded-md bg-red-50 p-4 text-sm text-red-600">
+          <p>Tu reservacion ha expirado. Por favor, crea una nueva.</p>
+          <Link
+            to="/reservations/new"
+            className="mt-2 inline-block font-medium text-indigo-600 hover:text-indigo-700"
+          >
+            Crear nueva reservacion
+          </Link>
+        </div>
+      </div>
+    );
+  }
+
+  if (isComplete) {
+    return (
+      <div className="mx-auto max-w-2xl px-4 py-8">
+        <h1 className="text-3xl font-bold text-gray-900">Pago exitoso</h1>
+        <div className="mt-6 rounded-lg border border-green-200 bg-green-50 p-4 text-sm text-green-700">
+          <p>Tu reservacion ha sido confirmada.</p>
+          {isAuthenticated ? (
+            <Link
+              to="/my-reservations"
+              className="mt-2 inline-block font-medium text-indigo-600 hover:text-indigo-700"
+            >
+              Ver mis reservaciones
+            </Link>
+          ) : (
+            <p className="mt-2">
+              Recibiras un correo con los detalles de tu reservacion.
+            </p>
+          )}
+        </div>
+      </div>
+    );
+  }
+
+  const handleSubmit = async (e: React.FormEvent) => {
+    e.preventDefault();
+    if (!stripe || !elements) return;
+
+    setIsProcessing(true);
+    setError("");
+
+    const returnPath = isAuthenticated ? "/my-reservations" : "/";
+    const { error: stripeError } = await stripe.confirmPayment({
+      elements,
+      confirmParams: {
+        return_url: `${window.location.origin}${returnPath}`,
+      },
+      redirect: "if_required",
+    });
+
+    if (stripeError) {
+      setError(stripeError.message ?? "Error al procesar el pago");
+      setIsProcessing(false);
+      return;
+    }
+
+    if (isAuthenticated) {
+      navigate("/my-reservations");
+      return;
+    }
+
+    setIsComplete(true);
+  };
+
+  return (
+    <div className="mx-auto max-w-2xl px-4 py-8">
+      <h1 className="text-3xl font-bold text-gray-900">Pago</h1>
+
+      <div className="mt-6 rounded-lg border border-gray-200 bg-gray-50 p-4">
+        <h2 className="font-medium text-gray-900">Resumen de reservacion</h2>
+        <dl className="mt-2 space-y-1 text-sm text-gray-600">
+          <div className="flex justify-between">
+            <dt>Fecha</dt>
+            <dd>{reservation.date}</dd>
+          </div>
+          <div className="flex justify-between">
+            <dt>Hora</dt>
+            <dd>{reservation.start_time}</dd>
+          </div>
+          <div className="flex justify-between">
+            <dt>Personas</dt>
+            <dd>{reservation.seats_requested}</dd>
+          </div>
+          {reservation.table && (
+            <div className="flex justify-between">
+              <dt>Mesa</dt>
+              <dd>{reservation.table.name}</dd>
+            </div>
+          )}
+          {reservation.payment && (
+            <div className="flex justify-between font-medium text-gray-900">
+              <dt>Deposito</dt>
+              <dd>{formatCurrency(reservation.payment.amount)}</dd>
+            </div>
+          )}
+        </dl>
+      </div>
+
+      {error && (
+        <p className="mt-4 rounded-md bg-red-50 p-3 text-sm text-red-600">
+          {error}
+        </p>
+      )}
+
+      <form onSubmit={handleSubmit} className="mt-6 flex flex-col gap-4">
+        <PaymentElement />
+        <button
+          type="submit"
+          disabled={isProcessing || !stripe || !elements}
+          className="rounded-md bg-indigo-600 py-2 text-sm font-medium text-white
+            transition-colors hover:bg-indigo-700
+            disabled:cursor-not-allowed disabled:opacity-50"
+        >
+          {isProcessing ? "Procesando..." : "Pagar deposito"}
+        </button>
+      </form>
+    </div>
+  );
+}
+
+export default function PaymentPage() {
+  const location = useLocation();
+  const state = location.state as PaymentRouteState | null;
+
+  if (!state?.clientSecret || !state?.reservation) {
+    return <Navigate to="/reservations/new" replace />;
+  }
+
+  return (
+    <Elements stripe={stripePromise} options={{ clientSecret: state.clientSecret }}>
+      <CheckoutForm reservation={state.reservation} />
+    </Elements>
+  );
+}

--- a/src/pages/__tests__/NewReservationPage.test.tsx
+++ b/src/pages/__tests__/NewReservationPage.test.tsx
@@ -59,10 +59,30 @@ function mockAvailableTables(tables: Table[] = MOCK_TABLES) {
   });
 }
 
+const MOCK_HOLD_RESERVATION = {
+  id: 10,
+  user_id: 1,
+  table: MOCK_TABLES[0],
+  seats_requested: 4,
+  date: "2026-04-10",
+  start_time: "19:00",
+  end_time: "21:00",
+  status: "pending" as const,
+  expires_at: "2026-04-10T19:15:00Z",
+  payment: { amount: "40.00", status: "pending", paid_at: "" },
+  created_at: "2026-04-08T10:00:00Z",
+};
+
+const MOCK_GUEST_RESERVATION = {
+  ...MOCK_HOLD_RESERVATION,
+  id: 11,
+  user_id: 2,
+};
+
 function mockCreateHold() {
   vi.mocked(reservationService.createHold).mockResolvedValue({
     data: {
-      reservation: { id: 10 } as never,
+      reservation: MOCK_HOLD_RESERVATION,
       payment_intent_client_secret: "pi_secret_123",
     },
   });
@@ -71,7 +91,7 @@ function mockCreateHold() {
 function mockCreateGuestReservation() {
   vi.mocked(guestService.createGuestReservation).mockResolvedValue({
     data: {
-      reservation: { id: 11 } as never,
+      reservation: MOCK_GUEST_RESERVATION,
       payment_intent_client_secret: "pi_secret_456",
     },
   });
@@ -265,7 +285,10 @@ describe("NewReservationPage", () => {
       await waitFor(() => {
         expect(reservationService.createHold).toHaveBeenCalled();
         expect(mockNavigate).toHaveBeenCalledWith("/payment", {
-          state: { clientSecret: "pi_secret_123", reservationId: 10 },
+          state: {
+            clientSecret: "pi_secret_123",
+            reservation: expect.objectContaining({ id: 10 }),
+          },
         });
       });
     });
@@ -335,7 +358,10 @@ describe("NewReservationPage", () => {
       await waitFor(() => {
         expect(guestService.createGuestReservation).toHaveBeenCalled();
         expect(mockNavigate).toHaveBeenCalledWith("/payment", {
-          state: { clientSecret: "pi_secret_456", reservationId: 11 },
+          state: {
+            clientSecret: "pi_secret_456",
+            reservation: expect.objectContaining({ id: 11 }),
+          },
         });
       });
     });

--- a/src/pages/__tests__/PaymentPage.test.tsx
+++ b/src/pages/__tests__/PaymentPage.test.tsx
@@ -1,0 +1,264 @@
+import { act, render, screen, waitFor } from "@testing-library/react";
+import userEvent from "@testing-library/user-event";
+import { MemoryRouter } from "react-router-dom";
+import PaymentPage from "../PaymentPage";
+import type { Reservation } from "../../types/api";
+
+const mockConfirmPayment = vi.fn();
+let mockStripe: unknown = { confirmPayment: mockConfirmPayment };
+let mockElements: unknown = {};
+
+vi.mock("@stripe/react-stripe-js", () => ({
+  Elements: ({ children }: { children: React.ReactNode }) => <>{children}</>,
+  PaymentElement: () => <div data-testid="payment-element" />,
+  useStripe: () => mockStripe,
+  useElements: () => mockElements,
+}));
+
+vi.mock("../../lib/stripe", () => ({
+  stripePromise: Promise.resolve({}),
+}));
+
+const mockNavigate = vi.fn();
+let mockLocationState: unknown = null;
+
+vi.mock("react-router-dom", async () => {
+  const actual = await vi.importActual("react-router-dom");
+  return {
+    ...actual,
+    useNavigate: () => mockNavigate,
+    useLocation: () => ({
+      state: mockLocationState,
+      pathname: "/payment",
+      search: "",
+      hash: "",
+      key: "default",
+    }),
+  };
+});
+
+let mockIsAuthenticated = false;
+
+vi.mock("../../context/AuthContext", () => ({
+  useAuth: () => ({
+    user: mockIsAuthenticated
+      ? { id: 1, name: "Test", email: "t@t.com", role: "client" }
+      : null,
+    isAuthenticated: mockIsAuthenticated,
+    login: vi.fn(),
+    register: vi.fn(),
+    logout: vi.fn(),
+    setSession: vi.fn(),
+  }),
+}));
+
+const MOCK_RESERVATION: Reservation = {
+  id: 10,
+  user_id: 1,
+  table: {
+    id: 1,
+    name: "Mesa 1",
+    min_capacity: 2,
+    max_capacity: 4,
+    location: "Interior",
+    description: null,
+    is_active: true,
+    created_at: "2026-01-01",
+  },
+  seats_requested: 4,
+  date: "2026-04-10",
+  start_time: "19:00",
+  end_time: "21:00",
+  status: "pending",
+  expires_at: "2099-12-31T23:59:59Z",
+  payment: { amount: "40.00", status: "pending", paid_at: "" },
+  created_at: "2026-04-08T10:00:00Z",
+};
+
+function renderPage() {
+  return render(
+    <MemoryRouter>
+      <PaymentPage />
+    </MemoryRouter>,
+  );
+}
+
+describe("PaymentPage", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    mockIsAuthenticated = false;
+    mockStripe = { confirmPayment: mockConfirmPayment };
+    mockElements = {};
+    mockLocationState = null;
+  });
+
+  describe("missing route state", () => {
+    it("redirects to /reservations/new when state is null", () => {
+      mockLocationState = null;
+      renderPage();
+
+      expect(
+        screen.queryByTestId("payment-element"),
+      ).not.toBeInTheDocument();
+      expect(screen.queryByText("Pago")).not.toBeInTheDocument();
+    });
+
+    it("redirects when clientSecret is missing", () => {
+      mockLocationState = { reservation: MOCK_RESERVATION };
+      renderPage();
+
+      expect(
+        screen.queryByTestId("payment-element"),
+      ).not.toBeInTheDocument();
+    });
+
+    it("redirects when reservation is missing", () => {
+      mockLocationState = { clientSecret: "pi_secret_123" };
+      renderPage();
+
+      expect(
+        screen.queryByTestId("payment-element"),
+      ).not.toBeInTheDocument();
+    });
+  });
+
+  describe("reservation summary", () => {
+    beforeEach(() => {
+      mockLocationState = {
+        clientSecret: "pi_secret_123",
+        reservation: MOCK_RESERVATION,
+      };
+    });
+
+    it("displays reservation details", () => {
+      renderPage();
+
+      expect(screen.getByText("2026-04-10")).toBeInTheDocument();
+      expect(screen.getByText("19:00")).toBeInTheDocument();
+      expect(screen.getByText("4")).toBeInTheDocument();
+      expect(screen.getByText("Mesa 1")).toBeInTheDocument();
+      expect(screen.getByText("$40.00")).toBeInTheDocument();
+    });
+
+    it("renders PaymentElement and submit button", () => {
+      renderPage();
+
+      expect(screen.getByTestId("payment-element")).toBeInTheDocument();
+      expect(
+        screen.getByRole("button", { name: "Pagar deposito" }),
+      ).toBeInTheDocument();
+    });
+  });
+
+  describe("expired reservation", () => {
+    it("shows expiration message and hides payment form", () => {
+      mockLocationState = {
+        clientSecret: "pi_secret_123",
+        reservation: {
+          ...MOCK_RESERVATION,
+          expires_at: "2020-01-01T00:00:00Z",
+        },
+      };
+      renderPage();
+
+      expect(
+        screen.getByText("Tu reservacion ha expirado. Por favor, crea una nueva."),
+      ).toBeInTheDocument();
+      expect(
+        screen.getByText("Crear nueva reservacion"),
+      ).toBeInTheDocument();
+      expect(
+        screen.queryByTestId("payment-element"),
+      ).not.toBeInTheDocument();
+    });
+  });
+
+  describe("payment submission", () => {
+    beforeEach(() => {
+      mockLocationState = {
+        clientSecret: "pi_secret_123",
+        reservation: MOCK_RESERVATION,
+      };
+    });
+
+    it("shows Stripe error inline on failure", async () => {
+      mockConfirmPayment.mockResolvedValue({
+        error: { message: "Tu tarjeta fue rechazada" },
+      });
+      renderPage();
+      const user = userEvent.setup();
+
+      await user.click(
+        screen.getByRole("button", { name: "Pagar deposito" }),
+      );
+
+      await waitFor(() => {
+        expect(
+          screen.getByText("Tu tarjeta fue rechazada"),
+        ).toBeInTheDocument();
+      });
+    });
+
+    it("shows button as processing during submission", async () => {
+      let resolvePayment: (value: unknown) => void;
+      mockConfirmPayment.mockReturnValue(
+        new Promise((resolve) => {
+          resolvePayment = resolve;
+        }),
+      );
+      renderPage();
+      const user = userEvent.setup();
+
+      await user.click(
+        screen.getByRole("button", { name: "Pagar deposito" }),
+      );
+
+      expect(screen.getByText("Procesando...")).toBeInTheDocument();
+      expect(
+        screen.getByRole("button", { name: "Procesando..." }),
+      ).toBeDisabled();
+
+      await act(async () => {
+        resolvePayment!({ error: undefined });
+      });
+    });
+
+    it("navigates to /my-reservations on success for authenticated user", async () => {
+      mockIsAuthenticated = true;
+      mockConfirmPayment.mockResolvedValue({ error: undefined });
+      renderPage();
+      const user = userEvent.setup();
+
+      await user.click(
+        screen.getByRole("button", { name: "Pagar deposito" }),
+      );
+
+      await waitFor(() => {
+        expect(mockNavigate).toHaveBeenCalledWith("/my-reservations");
+      });
+    });
+
+    it("shows success message for guest user", async () => {
+      mockIsAuthenticated = false;
+      mockConfirmPayment.mockResolvedValue({ error: undefined });
+      renderPage();
+      const user = userEvent.setup();
+
+      await user.click(
+        screen.getByRole("button", { name: "Pagar deposito" }),
+      );
+
+      await waitFor(() => {
+        expect(
+          screen.getByText("Tu reservacion ha sido confirmada."),
+        ).toBeInTheDocument();
+        expect(
+          screen.getByText(
+            "Recibiras un correo con los detalles de tu reservacion.",
+          ),
+        ).toBeInTheDocument();
+      });
+      expect(mockNavigate).not.toHaveBeenCalled();
+    });
+  });
+});

--- a/src/routes/Router.tsx
+++ b/src/routes/Router.tsx
@@ -10,6 +10,7 @@ import ForgotPasswordPage from "../pages/ForgotPasswordPage";
 import ResetPasswordPage from "../pages/ResetPasswordPage";
 import MenuPage from "../pages/MenuPage";
 import NewReservationPage from "../pages/NewReservationPage";
+import PaymentPage from "../pages/PaymentPage";
 
 // Placeholder components until real pages are built
 function Placeholder({ name }: { name: string }) {
@@ -41,10 +42,7 @@ export default function Router() {
               path="/reservations/new"
               element={<NewReservationPage />}
             />
-            <Route
-              path="/payment"
-              element={<Placeholder name="Payment" />}
-            />
+            <Route path="/payment" element={<PaymentPage />} />
             <Route
               path="/complete-account"
               element={<Placeholder name="Complete Account" />}


### PR DESCRIPTION
## Summary

- Add `PaymentPage` with Stripe `Elements` provider and `CheckoutForm` inner component
- Render reservation summary (date, time, seats, table, deposit amount) and `PaymentElement` for card input
- Handle hold expiration with message and link back to new reservation
- Differentiate post-payment flow: authenticated users navigate to `/my-reservations`, guests see inline success message
- Conditionally set Stripe `return_url` based on auth status for 3D Secure redirects
- Update `NewReservationPage` to pass full `reservation` object in route state instead of just `reservationId`
- Update `Router.tsx` to use `PaymentPage` instead of Placeholder
- Add 10 unit tests covering missing state, summary display, expiration, Stripe errors, and auth/guest success flows

## Test plan

- [x] 56 unit tests passing (`npm run test`)
- [x] TypeScript build passes (`npm run build`)
- [x] Linter passes (`npm run lint`)
- [ ] Manual: Login > New Reservation > select table > Reserve > verify Payment page shows summary and Stripe form
- [ ] Manual: Guest flow > New Reservation > fill guest data > Reserve > verify Payment page works without auth
- [ ] Manual: Navigate directly to `/payment` without state > verify redirect to `/reservations/new`

Closes #9