### PR TITLE
My Reservations screen

### DIFF
--- a/src/components/CancelModal.tsx
+++ b/src/components/CancelModal.tsx
@@ -1,0 +1,67 @@
+import { useEffect } from "react";
+
+interface CancelModalProps {
+  isOpen: boolean;
+  isSubmitting: boolean;
+  onConfirm: () => void;
+  onClose: () => void;
+}
+
+export default function CancelModal({
+  isOpen,
+  isSubmitting,
+  onConfirm,
+  onClose,
+}: CancelModalProps) {
+  useEffect(() => {
+    if (!isOpen) return;
+
+    function handleKeyDown(e: KeyboardEvent) {
+      if (e.key === "Escape" && !isSubmitting) onClose();
+    }
+
+    document.addEventListener("keydown", handleKeyDown);
+    return () => document.removeEventListener("keydown", handleKeyDown);
+  }, [isOpen, isSubmitting, onClose]);
+
+  if (!isOpen) return null;
+
+  return (
+    <div
+      className="fixed inset-0 z-50 flex items-center justify-center bg-black/50"
+      onClick={() => { if (!isSubmitting) onClose(); }}
+    >
+      <div
+        className="mx-4 w-full max-w-md rounded-lg bg-white p-6 shadow-lg"
+        onClick={(e) => e.stopPropagation()}
+      >
+        <h2 className="text-lg font-semibold text-gray-900">
+          Cancelar reservacion
+        </h2>
+        <p className="mt-2 text-sm text-gray-600">
+          Esta accion no se puede deshacer. Dependiendo de la politica de
+          cancelacion, podrias recibir un reembolso total o parcial.
+        </p>
+
+        <div className="mt-6 flex justify-end gap-3">
+          <button
+            type="button"
+            onClick={onClose}
+            disabled={isSubmitting}
+            className="rounded-md border border-gray-300 px-4 py-2 text-sm font-medium text-gray-700 hover:bg-gray-50 disabled:cursor-not-allowed disabled:opacity-50"
+          >
+            Volver
+          </button>
+          <button
+            type="button"
+            onClick={onConfirm}
+            disabled={isSubmitting}
+            className="rounded-md bg-red-600 px-4 py-2 text-sm font-medium text-white hover:bg-red-700 disabled:cursor-not-allowed disabled:opacity-50"
+          >
+            {isSubmitting ? "Cancelando..." : "Cancelar reservacion"}
+          </button>
+        </div>
+      </div>
+    </div>
+  );
+}

--- a/src/pages/MyReservationsPage.tsx
+++ b/src/pages/MyReservationsPage.tsx
@@ -1,0 +1,303 @@
+import { useEffect, useRef, useState } from "react";
+import { Link } from "react-router-dom";
+import CancelModal from "../components/CancelModal";
+import * as reservationService from "../services/reservation.service";
+import type { Reservation, ReservationStatus } from "../types/api";
+
+const STATUS_CONFIG: Record<
+  ReservationStatus,
+  { label: string; colors: string }
+> = {
+  pending: { label: "Pendiente", colors: "bg-yellow-100 text-yellow-800" },
+  confirmed: { label: "Confirmada", colors: "bg-green-100 text-green-800" },
+  completed: { label: "Completada", colors: "bg-blue-100 text-blue-800" },
+  cancelled: { label: "Cancelada", colors: "bg-red-100 text-red-800" },
+  expired: { label: "Expirada", colors: "bg-gray-100 text-gray-800" },
+  no_show: { label: "No asistio", colors: "bg-orange-100 text-orange-800" },
+};
+
+const CANCELLABLE_STATUSES: ReservationStatus[] = ["pending", "confirmed"];
+
+function formatDate(dateStr: string) {
+  const [year, month, day] = dateStr.split("-");
+  return `${day}/${month}/${year}`;
+}
+
+function formatTime(timeStr: string) {
+  return timeStr.slice(0, 5);
+}
+
+function StatusBadge({ status }: { status: ReservationStatus }) {
+  const config = STATUS_CONFIG[status];
+  return (
+    <span
+      className={`inline-block rounded-full px-3 py-1 text-xs font-medium ${config.colors}`}
+    >
+      {config.label}
+    </span>
+  );
+}
+
+export default function MyReservationsPage() {
+  const [reservations, setReservations] = useState<Reservation[]>([]);
+  const [isLoading, setIsLoading] = useState(true);
+  const [error, setError] = useState<string | null>(null);
+  const [expandedId, setExpandedId] = useState<number | null>(null);
+  const [detail, setDetail] = useState<Reservation | null>(null);
+  const [isDetailLoading, setIsDetailLoading] = useState(false);
+  const [cancellingId, setCancellingId] = useState<number | null>(null);
+  const [isCancelling, setIsCancelling] = useState(false);
+  const [cancelError, setCancelError] = useState<string | null>(null);
+  const detailRequestId = useRef(0);
+
+  useEffect(() => {
+    reservationService
+      .getAll()
+      .then((response) => setReservations(response.data))
+      .catch((err) =>
+        setError(
+          err instanceof Error ? err.message : "Error al cargar reservaciones",
+        ),
+      )
+      .finally(() => setIsLoading(false));
+  }, []);
+
+  function toggleAccordion(id: number) {
+    if (expandedId === id) {
+      setExpandedId(null);
+      setDetail(null);
+      return;
+    }
+
+    setExpandedId(id);
+    setDetail(null);
+    setIsDetailLoading(true);
+
+    const currentRequest = ++detailRequestId.current;
+
+    reservationService
+      .getById(id)
+      .then((response) => {
+        if (detailRequestId.current !== currentRequest) return;
+        setDetail(response.data);
+      })
+      .catch(() => {
+        if (detailRequestId.current !== currentRequest) return;
+        setDetail(null);
+      })
+      .finally(() => {
+        if (detailRequestId.current !== currentRequest) return;
+        setIsDetailLoading(false);
+      });
+  }
+
+  function handleCancelConfirm() {
+    if (!cancellingId) return;
+
+    setIsCancelling(true);
+
+    reservationService
+      .cancel(cancellingId)
+      .then((response) => {
+        setReservations((prev) =>
+          prev.map((r) => (r.id === cancellingId ? response.data : r)),
+        );
+        if (expandedId === cancellingId) {
+          setDetail(response.data);
+        }
+        setCancellingId(null);
+      })
+      .catch((err) => {
+        setCancelError(
+          err instanceof Error
+            ? err.message
+            : "Error al cancelar la reservacion",
+        );
+        setCancellingId(null);
+      })
+      .finally(() => setIsCancelling(false));
+  }
+
+  if (isLoading) {
+    return (
+      <div className="mx-auto max-w-3xl px-4 py-8">
+        <p className="text-center text-gray-600">
+          Cargando reservaciones...
+        </p>
+      </div>
+    );
+  }
+
+  if (error) {
+    return (
+      <div className="mx-auto max-w-3xl px-4 py-8">
+        <p className="rounded-md bg-red-50 p-4 text-center text-red-600">
+          {error}
+        </p>
+      </div>
+    );
+  }
+
+  if (reservations.length === 0) {
+    return (
+      <div className="mx-auto max-w-3xl px-4 py-8">
+        <h1 className="mb-6 text-2xl font-bold text-gray-900">
+          Mis reservaciones
+        </h1>
+        <p className="text-center text-gray-600">
+          No tienes reservaciones aun.
+        </p>
+      </div>
+    );
+  }
+
+  return (
+    <div className="mx-auto max-w-3xl px-4 py-8">
+      <h1 className="mb-6 text-2xl font-bold text-gray-900">
+        Mis reservaciones
+      </h1>
+
+      {cancelError && (
+        <div className="mb-4 flex items-center justify-between rounded-md bg-red-50 p-4">
+          <p className="text-sm text-red-600">{cancelError}</p>
+          <button
+            type="button"
+            onClick={() => setCancelError(null)}
+            className="text-sm font-medium text-red-600 hover:text-red-800"
+          >
+            Cerrar
+          </button>
+        </div>
+      )}
+
+      <div className="space-y-3">
+        {reservations.map((reservation) => {
+          const isExpanded = expandedId === reservation.id;
+
+          return (
+            <div
+              key={reservation.id}
+              className="overflow-hidden rounded-lg border border-gray-200 bg-white"
+            >
+              <button
+                type="button"
+                onClick={() => toggleAccordion(reservation.id)}
+                className="flex w-full items-center justify-between px-4 py-3 text-left hover:bg-gray-50"
+                aria-expanded={isExpanded}
+              >
+                <div className="flex items-center gap-4">
+                  <span className="font-medium text-gray-900">
+                    {formatDate(reservation.date)}
+                  </span>
+                  <span className="text-gray-600">
+                    {formatTime(reservation.start_time)}
+                  </span>
+                  {reservation.table && (
+                    <span className="text-gray-600">
+                      {reservation.table.name}
+                    </span>
+                  )}
+                </div>
+                <div className="flex items-center gap-3">
+                  <StatusBadge status={reservation.status} />
+                  <span className="text-gray-400">{isExpanded ? "▲" : "▼"}</span>
+                </div>
+              </button>
+
+              {isExpanded && (
+                <div className="border-t border-gray-200 px-4 py-4">
+                  {isDetailLoading ? (
+                    <p className="text-sm text-gray-600">
+                      Cargando detalles...
+                    </p>
+                  ) : detail ? (
+                    <div className="space-y-3">
+                      <div className="grid grid-cols-2 gap-x-4 gap-y-2 text-sm">
+                        <div>
+                          <span className="text-gray-500">Fecha</span>
+                          <p className="font-medium text-gray-900">
+                            {formatDate(detail.date)}
+                          </p>
+                        </div>
+                        <div>
+                          <span className="text-gray-500">Horario</span>
+                          <p className="font-medium text-gray-900">
+                            {formatTime(detail.start_time)} -{" "}
+                            {formatTime(detail.end_time)}
+                          </p>
+                        </div>
+                        <div>
+                          <span className="text-gray-500">Personas</span>
+                          <p className="font-medium text-gray-900">
+                            {detail.seats_requested}
+                          </p>
+                        </div>
+                        {detail.table && (
+                          <div>
+                            <span className="text-gray-500">Mesa</span>
+                            <p className="font-medium text-gray-900">
+                              {detail.table.name} · {detail.table.location}
+                            </p>
+                          </div>
+                        )}
+                        {detail.payment && (
+                          <>
+                            <div>
+                              <span className="text-gray-500">Deposito</span>
+                              <p className="font-medium text-gray-900">
+                                ${detail.payment.amount}
+                              </p>
+                            </div>
+                            <div>
+                              <span className="text-gray-500">
+                                Estado del pago
+                              </span>
+                              <p className="font-medium text-gray-900">
+                                {detail.payment.status}
+                              </p>
+                            </div>
+                          </>
+                        )}
+                      </div>
+
+                      <div className="flex gap-3 pt-2">
+                        {detail.status === "confirmed" && (
+                          <Link
+                            to={`/my-reservations/${detail.id}/pre-order`}
+                            className="rounded-md bg-indigo-600 px-4 py-2 text-sm font-medium text-white hover:bg-indigo-700"
+                          >
+                            Pre-ordenar
+                          </Link>
+                        )}
+                        {CANCELLABLE_STATUSES.includes(detail.status) && (
+                          <button
+                            type="button"
+                            onClick={() => setCancellingId(detail.id)}
+                            className="rounded-md border border-red-300 px-4 py-2 text-sm font-medium text-red-600 hover:bg-red-50"
+                          >
+                            Cancelar
+                          </button>
+                        )}
+                      </div>
+                    </div>
+                  ) : (
+                    <p className="text-sm text-red-600">
+                      No se pudieron cargar los detalles.
+                    </p>
+                  )}
+                </div>
+              )}
+            </div>
+          );
+        })}
+      </div>
+
+      <CancelModal
+        isOpen={cancellingId !== null}
+        isSubmitting={isCancelling}
+        onConfirm={handleCancelConfirm}
+        onClose={() => setCancellingId(null)}
+      />
+    </div>
+  );
+}

--- a/src/pages/__tests__/MyReservationsPage.test.tsx
+++ b/src/pages/__tests__/MyReservationsPage.test.tsx
@@ -1,0 +1,470 @@
+import { render, screen, waitFor, within } from "@testing-library/react";
+import userEvent from "@testing-library/user-event";
+import { MemoryRouter } from "react-router-dom";
+import MyReservationsPage from "../MyReservationsPage";
+import * as reservationService from "../../services/reservation.service";
+import type { Reservation, PaginatedResponse } from "../../types/api";
+
+vi.mock("../../services/reservation.service");
+
+vi.mock("../../context/AuthContext", () => ({
+  useAuth: () => ({
+    user: { id: 1, name: "Test", email: "t@t.com", role: "client" },
+    isAuthenticated: true,
+    login: vi.fn(),
+    register: vi.fn(),
+    logout: vi.fn(),
+    setSession: vi.fn(),
+  }),
+}));
+
+const MOCK_RESERVATIONS: Reservation[] = [
+  {
+    id: 1,
+    user_id: 1,
+    seats_requested: 4,
+    date: "2026-04-10",
+    start_time: "19:00",
+    end_time: "21:00",
+    status: "confirmed",
+    created_at: "2026-04-08T10:00:00Z",
+  },
+  {
+    id: 2,
+    user_id: 1,
+    seats_requested: 2,
+    date: "2026-04-12",
+    start_time: "20:00",
+    end_time: "22:00",
+    status: "cancelled",
+    created_at: "2026-04-09T10:00:00Z",
+  },
+  {
+    id: 3,
+    user_id: 1,
+    seats_requested: 6,
+    date: "2026-04-15",
+    start_time: "13:00",
+    end_time: "15:00",
+    status: "pending",
+    created_at: "2026-04-10T10:00:00Z",
+  },
+];
+
+const MOCK_DETAIL: Reservation = {
+  id: 1,
+  user_id: 1,
+  table: {
+    id: 1,
+    name: "Mesa 1",
+    min_capacity: 2,
+    max_capacity: 4,
+    location: "Interior",
+    description: null,
+    is_active: true,
+    created_at: "2026-01-01",
+  },
+  seats_requested: 4,
+  date: "2026-04-10",
+  start_time: "19:00",
+  end_time: "21:00",
+  status: "confirmed",
+  payment: { amount: "40.00", status: "paid", paid_at: "2026-04-08T10:05:00Z" },
+  created_at: "2026-04-08T10:00:00Z",
+};
+
+function mockGetAll(reservations: Reservation[] = MOCK_RESERVATIONS) {
+  const response: PaginatedResponse<Reservation> = {
+    data: reservations,
+    meta: {
+      current_page: 1,
+      last_page: 1,
+      per_page: 15,
+      total: reservations.length,
+    },
+  };
+  vi.mocked(reservationService.getAll).mockResolvedValue(response);
+}
+
+function mockGetById(detail: Reservation = MOCK_DETAIL) {
+  vi.mocked(reservationService.getById).mockResolvedValue({ data: detail });
+}
+
+function renderPage() {
+  return render(
+    <MemoryRouter>
+      <MyReservationsPage />
+    </MemoryRouter>,
+  );
+}
+
+describe("MyReservationsPage", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it("shows loading state initially", () => {
+    vi.mocked(reservationService.getAll).mockReturnValue(new Promise(() => {}));
+    renderPage();
+
+    expect(screen.getByText("Cargando reservaciones...")).toBeInTheDocument();
+  });
+
+  it("renders reservation list after fetch", async () => {
+    mockGetAll();
+    renderPage();
+
+    await waitFor(() => {
+      expect(screen.getByText("10/04/2026")).toBeInTheDocument();
+    });
+
+    expect(screen.getByText("12/04/2026")).toBeInTheDocument();
+    expect(screen.getByText("15/04/2026")).toBeInTheDocument();
+  });
+
+  it("shows empty state when no reservations", async () => {
+    mockGetAll([]);
+    renderPage();
+
+    await waitFor(() => {
+      expect(
+        screen.getByText("No tienes reservaciones aun."),
+      ).toBeInTheDocument();
+    });
+  });
+
+  it("shows error when fetch fails", async () => {
+    vi.mocked(reservationService.getAll).mockRejectedValue(
+      new Error("Error del servidor"),
+    );
+    renderPage();
+
+    await waitFor(() => {
+      expect(screen.getByText("Error del servidor")).toBeInTheDocument();
+    });
+  });
+
+  it("displays correct status badges", async () => {
+    mockGetAll();
+    renderPage();
+
+    await waitFor(() => {
+      expect(screen.getByText("Confirmada")).toBeInTheDocument();
+    });
+
+    expect(screen.getByText("Cancelada")).toBeInTheDocument();
+    expect(screen.getByText("Pendiente")).toBeInTheDocument();
+  });
+
+  it("expands accordion on click and shows detail", async () => {
+    mockGetAll();
+    mockGetById();
+    renderPage();
+    const user = userEvent.setup();
+
+    await waitFor(() => {
+      expect(screen.getByText("10/04/2026")).toBeInTheDocument();
+    });
+
+    await user.click(screen.getByText("10/04/2026"));
+
+    await waitFor(() => {
+      expect(screen.getByText("Mesa 1 · Interior")).toBeInTheDocument();
+    });
+
+    expect(screen.getByText("$40.00")).toBeInTheDocument();
+    expect(screen.getByText("19:00 - 21:00")).toBeInTheDocument();
+    expect(screen.getByText("4")).toBeInTheDocument();
+  });
+
+  it("collapses accordion when clicking expanded item", async () => {
+    mockGetAll();
+    mockGetById();
+    renderPage();
+    const user = userEvent.setup();
+
+    await waitFor(() => {
+      expect(screen.getByText("10/04/2026")).toBeInTheDocument();
+    });
+
+    const headerButton = screen.getByText("10/04/2026").closest("button")!;
+    await user.click(headerButton);
+
+    await waitFor(() => {
+      expect(screen.getByText("Mesa 1 · Interior")).toBeInTheDocument();
+    });
+
+    await user.click(headerButton);
+
+    await waitFor(() => {
+      expect(screen.queryByText("Mesa 1 · Interior")).not.toBeInTheDocument();
+    });
+  });
+
+  it("shows detail loading state while fetching", async () => {
+    mockGetAll();
+    vi.mocked(reservationService.getById).mockReturnValue(
+      new Promise(() => {}),
+    );
+    renderPage();
+    const user = userEvent.setup();
+
+    await waitFor(() => {
+      expect(screen.getByText("10/04/2026")).toBeInTheDocument();
+    });
+
+    await user.click(screen.getByText("10/04/2026"));
+
+    expect(screen.getByText("Cargando detalles...")).toBeInTheDocument();
+  });
+
+  it("shows cancel button only for cancellable statuses", async () => {
+    mockGetAll();
+    mockGetById();
+    renderPage();
+    const user = userEvent.setup();
+
+    // Expand confirmed reservation — should show cancel
+    await waitFor(() => {
+      expect(screen.getByText("10/04/2026")).toBeInTheDocument();
+    });
+
+    await user.click(screen.getByText("10/04/2026"));
+
+    await waitFor(() => {
+      expect(screen.getByText("Mesa 1 · Interior")).toBeInTheDocument();
+    });
+
+    expect(
+      screen.getByRole("button", { name: "Cancelar" }),
+    ).toBeInTheDocument();
+  });
+
+  it("does not show cancel button for cancelled reservation", async () => {
+    const cancelledDetail: Reservation = {
+      ...MOCK_DETAIL,
+      id: 2,
+      status: "cancelled",
+    };
+    mockGetAll();
+    vi.mocked(reservationService.getById).mockResolvedValue({
+      data: cancelledDetail,
+    });
+    renderPage();
+    const user = userEvent.setup();
+
+    await waitFor(() => {
+      expect(screen.getByText("12/04/2026")).toBeInTheDocument();
+    });
+
+    await user.click(screen.getByText("12/04/2026"));
+
+    await waitFor(() => {
+      expect(screen.getByText("Mesa 1 · Interior")).toBeInTheDocument();
+    });
+
+    expect(
+      screen.queryByRole("button", { name: "Cancelar" }),
+    ).not.toBeInTheDocument();
+  });
+
+  it("opens cancel modal and cancels reservation on confirm", async () => {
+    const cancelledReservation: Reservation = {
+      ...MOCK_DETAIL,
+      status: "cancelled",
+    };
+    vi.mocked(reservationService.cancel).mockResolvedValue({
+      data: cancelledReservation,
+    });
+    mockGetAll();
+    mockGetById();
+    renderPage();
+    const user = userEvent.setup();
+
+    await waitFor(() => {
+      expect(screen.getByText("10/04/2026")).toBeInTheDocument();
+    });
+
+    await user.click(screen.getByText("10/04/2026").closest("button")!);
+
+    await waitFor(() => {
+      expect(
+        screen.getByRole("button", { name: "Cancelar" }),
+      ).toBeInTheDocument();
+    });
+
+    await user.click(screen.getByRole("button", { name: "Cancelar" }));
+
+    // Modal should be open
+    expect(
+      screen.getByText(/Esta accion no se puede deshacer/),
+    ).toBeInTheDocument();
+
+    await user.click(
+      screen.getByRole("button", { name: "Cancelar reservacion" }),
+    );
+
+    await waitFor(() => {
+      expect(reservationService.cancel).toHaveBeenCalledWith(1);
+    });
+
+    // Status should update in the list
+    const badges = screen.getAllByText("Cancelada");
+    expect(badges.length).toBeGreaterThanOrEqual(2);
+  });
+
+  it("closes cancel modal when Volver is clicked", async () => {
+    mockGetAll();
+    mockGetById();
+    renderPage();
+    const user = userEvent.setup();
+
+    await waitFor(() => {
+      expect(screen.getByText("10/04/2026")).toBeInTheDocument();
+    });
+
+    await user.click(screen.getByText("10/04/2026").closest("button")!);
+
+    await waitFor(() => {
+      expect(
+        screen.getByRole("button", { name: "Cancelar" }),
+      ).toBeInTheDocument();
+    });
+
+    await user.click(screen.getByRole("button", { name: "Cancelar" }));
+    expect(
+      screen.getByText(/Esta accion no se puede deshacer/),
+    ).toBeInTheDocument();
+
+    await user.click(screen.getByRole("button", { name: "Volver" }));
+
+    await waitFor(() => {
+      expect(
+        screen.queryByText(/Esta accion no se puede deshacer/),
+      ).not.toBeInTheDocument();
+    });
+  });
+
+  it("shows pre-order link for confirmed reservations", async () => {
+    mockGetAll();
+    mockGetById();
+    renderPage();
+    const user = userEvent.setup();
+
+    await waitFor(() => {
+      expect(screen.getByText("10/04/2026")).toBeInTheDocument();
+    });
+
+    await user.click(screen.getByText("10/04/2026"));
+
+    await waitFor(() => {
+      expect(screen.getByText("Pre-ordenar")).toBeInTheDocument();
+    });
+
+    const link = screen.getByRole("link", { name: "Pre-ordenar" });
+    expect(link).toHaveAttribute("href", "/my-reservations/1/pre-order");
+  });
+
+  it("does not show pre-order link for pending reservations", async () => {
+    const pendingDetail: Reservation = {
+      ...MOCK_DETAIL,
+      id: 3,
+      status: "pending",
+    };
+    mockGetAll();
+    vi.mocked(reservationService.getById).mockResolvedValue({
+      data: pendingDetail,
+    });
+    renderPage();
+    const user = userEvent.setup();
+
+    await waitFor(() => {
+      expect(screen.getByText("15/04/2026")).toBeInTheDocument();
+    });
+
+    await user.click(screen.getByText("15/04/2026"));
+
+    await waitFor(() => {
+      expect(screen.getByText("Mesa 1 · Interior")).toBeInTheDocument();
+    });
+
+    expect(screen.queryByText("Pre-ordenar")).not.toBeInTheDocument();
+  });
+
+  it("shows cancel error as banner without destroying the list", async () => {
+    vi.mocked(reservationService.cancel).mockRejectedValue(
+      new Error("No se puede cancelar"),
+    );
+    mockGetAll();
+    mockGetById();
+    renderPage();
+    const user = userEvent.setup();
+
+    await waitFor(() => {
+      expect(screen.getByText("10/04/2026")).toBeInTheDocument();
+    });
+
+    await user.click(screen.getByText("10/04/2026").closest("button")!);
+
+    await waitFor(() => {
+      expect(
+        screen.getByRole("button", { name: "Cancelar" }),
+      ).toBeInTheDocument();
+    });
+
+    await user.click(screen.getByRole("button", { name: "Cancelar" }));
+    await user.click(
+      screen.getByRole("button", { name: "Cancelar reservacion" }),
+    );
+
+    await waitFor(() => {
+      expect(screen.getByText("No se puede cancelar")).toBeInTheDocument();
+    });
+
+    // List should still be visible (date appears in header + detail)
+    expect(screen.getAllByText("10/04/2026").length).toBeGreaterThanOrEqual(1);
+    expect(screen.getByText("12/04/2026")).toBeInTheDocument();
+
+    // Error banner can be dismissed
+    await user.click(screen.getByRole("button", { name: "Cerrar" }));
+
+    expect(
+      screen.queryByText("No se puede cancelar"),
+    ).not.toBeInTheDocument();
+  });
+
+  it("closes modal when clicking on overlay", async () => {
+    mockGetAll();
+    mockGetById();
+    renderPage();
+    const user = userEvent.setup();
+
+    await waitFor(() => {
+      expect(screen.getByText("10/04/2026")).toBeInTheDocument();
+    });
+
+    await user.click(screen.getByText("10/04/2026").closest("button")!);
+
+    await waitFor(() => {
+      expect(
+        screen.getByRole("button", { name: "Cancelar" }),
+      ).toBeInTheDocument();
+    });
+
+    await user.click(screen.getByRole("button", { name: "Cancelar" }));
+    expect(
+      screen.getByText(/Esta accion no se puede deshacer/),
+    ).toBeInTheDocument();
+
+    // Click on the overlay (the outer div of the modal)
+    const overlay = screen.getByText(/Esta accion no se puede deshacer/)
+      .closest(".fixed")!;
+    await user.click(overlay);
+
+    await waitFor(() => {
+      expect(
+        screen.queryByText(/Esta accion no se puede deshacer/),
+      ).not.toBeInTheDocument();
+    });
+  });
+});

--- a/src/routes/Router.tsx
+++ b/src/routes/Router.tsx
@@ -11,6 +11,7 @@ import ResetPasswordPage from "../pages/ResetPasswordPage";
 import MenuPage from "../pages/MenuPage";
 import NewReservationPage from "../pages/NewReservationPage";
 import PaymentPage from "../pages/PaymentPage";
+import MyReservationsPage from "../pages/MyReservationsPage";
 
 // Placeholder components until real pages are built
 function Placeholder({ name }: { name: string }) {
@@ -52,7 +53,7 @@ export default function Router() {
             <Route element={<ProtectedRoute />}>
               <Route
                 path="/my-reservations"
-                element={<Placeholder name="My Reservations" />}
+                element={<MyReservationsPage />}
               />
               <Route
                 path="/my-reservations/:id/pre-order"


### PR DESCRIPTION
## Summary

- Add My Reservations page with accordion list that lazy-loads reservation details on expand
- Add CancelModal component with overlay click and Escape key dismissal
- Cancel flow updates reservation in-place without re-fetching the list
- Status badges with color coding for all reservation states (pending, confirmed, completed, cancelled, expired, no_show)
- Pre-order link for confirmed reservations
- Race condition protection on rapid accordion toggling via request counter
- Cancel errors shown as dismissible banner without destroying the list view
- 16 tests covering loading, empty, error, accordion, cancel modal, pre-order link, and status badges

## Test plan

- [x] Loading state renders while fetching reservations
- [x] Reservation list renders with correct dates and status badges
- [x] Empty state shown when no reservations exist
- [x] Error state shown when fetch fails
- [x] Accordion expands and shows detail (table, payment, schedule)
- [x] Accordion collapses on re-click
- [x] Cancel button visible only for pending/confirmed reservations
- [x] Cancel modal opens, confirms cancellation, and updates list
- [x] Cancel modal closes via Volver button and overlay click
- [x] Cancel error displays as banner without losing the list
- [x] Pre-order link shown only for confirmed reservations
- [x] All 72 tests pass (16 new + 56 existing)

Closes #11