### PR TITLE
Pre-order screen

### DIFF
--- a/src/components/MenuBrowser.tsx
+++ b/src/components/MenuBrowser.tsx
@@ -1,0 +1,152 @@
+import { useState } from "react";
+import type { MenuCategory, MenuItem } from "../types/api";
+
+const CATEGORIES: { value: MenuCategory; label: string }[] = [
+  { value: "entrantes", label: "Entrantes" },
+  { value: "principales", label: "Principales" },
+  { value: "postres", label: "Postres" },
+  { value: "bebidas", label: "Bebidas" },
+];
+
+interface MenuBrowserProps {
+  items: MenuItem[];
+  activeCategory: MenuCategory | null;
+  isLoading: boolean;
+  error: string;
+  addingItemId: number | null;
+  onCategoryChange: (category: MenuCategory | null) => void;
+  onAddItem: (menuItemId: number, quantity: number) => void;
+}
+
+function MenuItemCard({
+  item,
+  addingItemId,
+  onAddItem,
+}: {
+  item: MenuItem;
+  addingItemId: number | null;
+  onAddItem: (menuItemId: number, quantity: number) => void;
+}) {
+  const [quantity, setQuantity] = useState(1);
+  const isAdding = addingItemId === item.id;
+
+  return (
+    <div className="rounded-lg border border-gray-200 bg-white p-4">
+      <div className="flex items-start justify-between gap-3">
+        <div>
+          <h3 className="font-medium text-gray-900">{item.name}</h3>
+          {item.description && (
+            <p className="mt-1 text-sm text-gray-500">{item.description}</p>
+          )}
+        </div>
+        <span className="shrink-0 font-semibold text-indigo-600">
+          ${item.price}
+        </span>
+      </div>
+
+      <div className="mt-3 flex items-center gap-2">
+        <input
+          type="number"
+          min={1}
+          value={quantity}
+          onChange={(e) => setQuantity(Math.max(1, Number(e.target.value)))}
+          disabled={!item.is_available || isAdding}
+          className="w-16 rounded-md border border-gray-300 px-2 py-1 text-sm text-gray-900 disabled:opacity-50"
+        />
+        <button
+          type="button"
+          onClick={() => onAddItem(item.id, quantity)}
+          disabled={!item.is_available || isAdding}
+          className="rounded-md bg-indigo-600 px-3 py-1 text-sm font-medium text-white transition-colors hover:bg-indigo-700 disabled:opacity-50"
+        >
+          {isAdding ? "Agregando..." : "Agregar"}
+        </button>
+      </div>
+
+      {!item.is_available && (
+        <p className="mt-1 text-xs text-red-500">No disponible</p>
+      )}
+    </div>
+  );
+}
+
+export default function MenuBrowser({
+  items,
+  activeCategory,
+  isLoading,
+  error,
+  addingItemId,
+  onCategoryChange,
+  onAddItem,
+}: MenuBrowserProps) {
+  const groupedItems = activeCategory
+    ? { [activeCategory]: items }
+    : items.reduce<Record<string, MenuItem[]>>((acc, item) => {
+        const group = acc[item.category] ?? [];
+        group.push(item);
+        acc[item.category] = group;
+        return acc;
+      }, {});
+
+  return (
+    <div>
+      <h2 className="text-xl font-semibold text-gray-900">Menu</h2>
+
+      <div className="mt-4 flex flex-wrap gap-2">
+        <button
+          type="button"
+          onClick={() => onCategoryChange(null)}
+          className={`rounded-full px-4 py-2 text-sm font-medium transition-colors
+            ${!activeCategory
+              ? "bg-indigo-600 text-white"
+              : "bg-gray-100 text-gray-700 hover:bg-gray-200"}`}
+        >
+          Todos
+        </button>
+        {CATEGORIES.map((cat) => (
+          <button
+            key={cat.value}
+            type="button"
+            onClick={() => onCategoryChange(cat.value)}
+            className={`rounded-full px-4 py-2 text-sm font-medium transition-colors
+              ${activeCategory === cat.value
+                ? "bg-indigo-600 text-white"
+                : "bg-gray-100 text-gray-700 hover:bg-gray-200"}`}
+          >
+            {cat.label}
+          </button>
+        ))}
+      </div>
+
+      {isLoading && <p className="mt-6 text-gray-500">Cargando menu...</p>}
+
+      {error && <p className="mt-6 text-red-600">{error}</p>}
+
+      {!isLoading && !error && items.length === 0 && (
+        <p className="mt-6 text-gray-500">No hay items disponibles.</p>
+      )}
+
+      {!isLoading && !error && items.length > 0 && (
+        <div className="mt-6 space-y-8">
+          {CATEGORIES.filter((cat) => groupedItems[cat.value]).map((cat) => (
+            <section key={cat.value}>
+              <h3 className="text-lg font-semibold text-gray-800">
+                {cat.label}
+              </h3>
+              <div className="mt-3 grid gap-4 sm:grid-cols-2">
+                {groupedItems[cat.value].map((item) => (
+                  <MenuItemCard
+                    key={item.id}
+                    item={item}
+                    addingItemId={addingItemId}
+                    onAddItem={onAddItem}
+                  />
+                ))}
+              </div>
+            </section>
+          ))}
+        </div>
+      )}
+    </div>
+  );
+}

--- a/src/components/PreOrderSummary.tsx
+++ b/src/components/PreOrderSummary.tsx
@@ -1,0 +1,69 @@
+import type { ReservationItem } from "../types/api";
+
+interface PreOrderSummaryProps {
+  items: ReservationItem[];
+  removingItemId: number | null;
+  onRemoveItem: (itemId: number) => void;
+}
+
+export default function PreOrderSummary({
+  items,
+  removingItemId,
+  onRemoveItem,
+}: PreOrderSummaryProps) {
+  const total = items.reduce((sum, item) => sum + Number(item.subtotal), 0);
+
+  return (
+    <div className="rounded-lg border border-gray-200 bg-white p-4 lg:sticky lg:top-8">
+      <h2 className="text-xl font-semibold text-gray-900">Tu pre-orden</h2>
+
+      {items.length === 0 && (
+        <p className="mt-4 text-sm text-gray-500">
+          No has agregado items aun.
+        </p>
+      )}
+
+      {items.length > 0 && (
+        <>
+          <div className="mt-4 divide-y divide-gray-100">
+            {items.map((item) => (
+              <div
+                key={item.id}
+                className="flex items-center justify-between py-3"
+              >
+                <div>
+                  <p className="font-medium text-gray-900">
+                    {item.menu_item.name}
+                  </p>
+                  <p className="text-sm text-gray-500">
+                    {item.quantity} x ${item.unit_price}
+                  </p>
+                </div>
+                <div className="flex items-center gap-3">
+                  <span className="font-medium text-gray-900">
+                    ${item.subtotal}
+                  </span>
+                  <button
+                    type="button"
+                    onClick={() => onRemoveItem(item.id)}
+                    disabled={removingItemId === item.id}
+                    className="text-sm font-medium text-red-600 hover:text-red-800 disabled:opacity-50"
+                  >
+                    {removingItemId === item.id ? "..." : "Eliminar"}
+                  </button>
+                </div>
+              </div>
+            ))}
+          </div>
+
+          <div className="mt-4 flex justify-between border-t border-gray-200 pt-4">
+            <span className="text-lg font-semibold text-gray-900">Total</span>
+            <span className="text-lg font-semibold text-indigo-600">
+              ${total.toFixed(2)}
+            </span>
+          </div>
+        </>
+      )}
+    </div>
+  );
+}

--- a/src/pages/PreOrderPage.tsx
+++ b/src/pages/PreOrderPage.tsx
@@ -1,0 +1,245 @@
+import { useEffect, useState } from "react";
+import { Link, useNavigate, useParams } from "react-router-dom";
+import MenuBrowser from "../components/MenuBrowser";
+import PreOrderSummary from "../components/PreOrderSummary";
+import * as reservationService from "../services/reservation.service";
+import * as menuService from "../services/menu.service";
+import * as preOrderService from "../services/pre-order.service";
+import type {
+  MenuCategory,
+  MenuItem,
+  Reservation,
+  ReservationItem,
+} from "../types/api";
+
+function formatDate(dateStr: string) {
+  const [year, month, day] = dateStr.split("-");
+  return `${day}/${month}/${year}`;
+}
+
+function formatTime(timeStr: string) {
+  return timeStr.slice(0, 5);
+}
+
+export default function PreOrderPage() {
+  const { id } = useParams<{ id: string }>();
+  const navigate = useNavigate();
+
+  const [reservation, setReservation] = useState<Reservation | null>(null);
+  const [menuItems, setMenuItems] = useState<MenuItem[]>([]);
+  const [preOrderItems, setPreOrderItems] = useState<ReservationItem[]>([]);
+  const [activeCategory, setActiveCategory] = useState<MenuCategory | null>(
+    null,
+  );
+  const [isPageLoading, setIsPageLoading] = useState(true);
+  const [isMenuLoading, setIsMenuLoading] = useState(false);
+  const [error, setError] = useState("");
+  const [menuError, setMenuError] = useState("");
+  const [orderError, setOrderError] = useState("");
+  const [addingItemId, setAddingItemId] = useState<number | null>(null);
+  const [removingItemId, setRemovingItemId] = useState<number | null>(null);
+
+  const reservationId = Number(id);
+
+  useEffect(() => {
+    if (Number.isNaN(reservationId)) {
+      navigate("/my-reservations", { replace: true });
+      return;
+    }
+
+    reservationService
+      .getById(reservationId)
+      .then((response) => {
+        if (response.data.status !== "confirmed") {
+          setError("Esta reservacion no permite pre-ordenes.");
+          setIsPageLoading(false);
+          return;
+        }
+
+        setReservation(response.data);
+
+        return Promise.all([
+          menuService.getMenuItems(),
+          preOrderService.getItems(reservationId),
+        ]).then(([menuResponse, preOrderResponse]) => {
+          setMenuItems(menuResponse.data);
+          setPreOrderItems(preOrderResponse.data);
+          setIsPageLoading(false);
+        });
+      })
+      .catch((err: unknown) => {
+        const message =
+          err instanceof Error ? err.message : "Error al cargar la reservacion";
+        setError(message);
+        setIsPageLoading(false);
+      });
+  }, [reservationId, navigate]);
+
+  const [categoryInitialized, setCategoryInitialized] = useState(false);
+
+  useEffect(() => {
+    if (!reservation) return;
+
+    if (!categoryInitialized) {
+      setCategoryInitialized(true);
+      return;
+    }
+
+    setMenuError("");
+    setIsMenuLoading(true);
+
+    const category = activeCategory ?? undefined;
+    menuService
+      .getMenuItems(category)
+      .then((response) => setMenuItems(response.data))
+      .catch((err: unknown) => {
+        const message =
+          err instanceof Error ? err.message : "Error al cargar el menu";
+        setMenuError(message);
+      })
+      .finally(() => setIsMenuLoading(false));
+  }, [activeCategory, reservation, categoryInitialized]);
+
+  function refreshPreOrderItems() {
+    return preOrderService
+      .getItems(reservationId)
+      .then((response) => setPreOrderItems(response.data));
+  }
+
+  function handleAddItem(menuItemId: number, quantity: number) {
+    setAddingItemId(menuItemId);
+    setOrderError("");
+
+    preOrderService
+      .addItem(reservationId, { menu_item_id: menuItemId, quantity })
+      .then(() => refreshPreOrderItems())
+      .catch((err: unknown) => {
+        const message =
+          err instanceof Error ? err.message : "Error al agregar item";
+        setOrderError(message);
+      })
+      .finally(() => setAddingItemId(null));
+  }
+
+  function handleRemoveItem(itemId: number) {
+    setRemovingItemId(itemId);
+    setOrderError("");
+
+    preOrderService
+      .removeItem(reservationId, itemId)
+      .then(() => refreshPreOrderItems())
+      .catch((err: unknown) => {
+        const message =
+          err instanceof Error ? err.message : "Error al eliminar item";
+        setOrderError(message);
+      })
+      .finally(() => setRemovingItemId(null));
+  }
+
+  if (isPageLoading) {
+    return (
+      <div className="mx-auto max-w-6xl px-4 py-8">
+        <p className="text-center text-gray-600">Cargando...</p>
+      </div>
+    );
+  }
+
+  if (error) {
+    return (
+      <div className="mx-auto max-w-6xl px-4 py-8">
+        <p className="rounded-md bg-red-50 p-4 text-center text-red-600">
+          {error}
+        </p>
+        <div className="mt-4 text-center">
+          <Link
+            to="/my-reservations"
+            className="text-sm font-medium text-indigo-600 hover:text-indigo-800"
+          >
+            Volver a mis reservaciones
+          </Link>
+        </div>
+      </div>
+    );
+  }
+
+  if (!reservation) return null;
+
+  return (
+    <div className="mx-auto max-w-6xl px-4 py-8">
+      <Link
+        to="/my-reservations"
+        className="text-sm font-medium text-indigo-600 hover:text-indigo-800"
+      >
+        &larr; Volver a mis reservaciones
+      </Link>
+
+      <h1 className="mt-4 text-2xl font-bold text-gray-900">Pre-orden</h1>
+
+      <div className="mt-4 rounded-lg border border-gray-200 bg-gray-50 p-4">
+        <div className="grid grid-cols-2 gap-x-4 gap-y-2 text-sm sm:grid-cols-4">
+          <div>
+            <span className="text-gray-500">Fecha</span>
+            <p className="font-medium text-gray-900">
+              {formatDate(reservation.date)}
+            </p>
+          </div>
+          <div>
+            <span className="text-gray-500">Horario</span>
+            <p className="font-medium text-gray-900">
+              {formatTime(reservation.start_time)} -{" "}
+              {formatTime(reservation.end_time)}
+            </p>
+          </div>
+          <div>
+            <span className="text-gray-500">Personas</span>
+            <p className="font-medium text-gray-900">
+              {reservation.seats_requested}
+            </p>
+          </div>
+          {reservation.table && (
+            <div>
+              <span className="text-gray-500">Mesa</span>
+              <p className="font-medium text-gray-900">
+                {reservation.table.name}
+              </p>
+            </div>
+          )}
+        </div>
+      </div>
+
+      {orderError && (
+        <div className="mt-4 flex items-center justify-between rounded-md bg-red-50 p-4">
+          <p className="text-sm text-red-600">{orderError}</p>
+          <button
+            type="button"
+            onClick={() => setOrderError("")}
+            className="text-sm font-medium text-red-600 hover:text-red-800"
+          >
+            Cerrar
+          </button>
+        </div>
+      )}
+
+      <div className="mt-8 grid gap-8 lg:grid-cols-5">
+        <div className="lg:col-span-3">
+          <MenuBrowser
+            items={menuItems}
+            activeCategory={activeCategory}
+            isLoading={isMenuLoading}
+            error={menuError}
+            addingItemId={addingItemId}
+            onCategoryChange={setActiveCategory}
+            onAddItem={handleAddItem}
+          />
+        </div>
+        <div className="lg:col-span-2">
+          <PreOrderSummary
+            items={preOrderItems}
+            removingItemId={removingItemId}
+            onRemoveItem={handleRemoveItem}
+          />
+        </div>
+      </div>
+    </div>
+  );
+}

--- a/src/pages/__tests__/PreOrderPage.test.tsx
+++ b/src/pages/__tests__/PreOrderPage.test.tsx
@@ -1,0 +1,357 @@
+import { render, screen, waitFor } from "@testing-library/react";
+import userEvent from "@testing-library/user-event";
+import { MemoryRouter } from "react-router-dom";
+import PreOrderPage from "../PreOrderPage";
+import * as reservationService from "../../services/reservation.service";
+import * as menuService from "../../services/menu.service";
+import * as preOrderService from "../../services/pre-order.service";
+import type {
+  MenuItem,
+  Reservation,
+  ReservationItem,
+} from "../../types/api";
+
+vi.mock("../../services/reservation.service");
+vi.mock("../../services/menu.service");
+vi.mock("../../services/pre-order.service");
+
+const mockNavigate = vi.fn();
+
+vi.mock("react-router-dom", async () => {
+  const actual = await vi.importActual("react-router-dom");
+  return {
+    ...actual,
+    useParams: () => ({ id: "1" }),
+    useNavigate: () => mockNavigate,
+  };
+});
+
+vi.mock("../../context/AuthContext", () => ({
+  useAuth: () => ({
+    user: { id: 1, name: "Test", email: "t@t.com", role: "client" },
+    isAuthenticated: true,
+    login: vi.fn(),
+    register: vi.fn(),
+    logout: vi.fn(),
+    setSession: vi.fn(),
+  }),
+}));
+
+const MOCK_RESERVATION: Reservation = {
+  id: 1,
+  user_id: 1,
+  table: {
+    id: 1,
+    name: "Mesa 1",
+    min_capacity: 2,
+    max_capacity: 4,
+    location: "Interior",
+    description: null,
+    is_active: true,
+    created_at: "2026-01-01",
+  },
+  seats_requested: 4,
+  date: "2026-04-10",
+  start_time: "19:00",
+  end_time: "21:00",
+  status: "confirmed",
+  payment: { amount: "40.00", status: "paid", paid_at: "2026-04-08T10:05:00Z" },
+  created_at: "2026-04-08T10:00:00Z",
+};
+
+const MOCK_MENU_ITEMS: MenuItem[] = [
+  {
+    id: 10,
+    name: "Ensalada Cesar",
+    description: "Lechuga romana con aderezo cesar",
+    price: "8.50",
+    category: "entrantes",
+    is_available: true,
+    daily_stock: 10,
+    created_at: "2026-01-01",
+  },
+  {
+    id: 20,
+    name: "Lomo Saltado",
+    description: "Carne de res salteada con verduras",
+    price: "18.00",
+    category: "principales",
+    is_available: true,
+    daily_stock: 5,
+    created_at: "2026-01-01",
+  },
+  {
+    id: 30,
+    name: "Tiramisú",
+    description: null,
+    price: "7.00",
+    category: "postres",
+    is_available: false,
+    daily_stock: 0,
+    created_at: "2026-01-01",
+  },
+];
+
+const MOCK_PRE_ORDER_ITEMS: ReservationItem[] = [
+  {
+    id: 100,
+    quantity: 2,
+    unit_price: "8.50",
+    subtotal: "17.00",
+    menu_item: { id: 10, name: "Ensalada Cesar", category: "entrantes" },
+    created_at: "2026-04-09T10:00:00Z",
+  },
+];
+
+function mockDefaultServices() {
+  vi.mocked(reservationService.getById).mockResolvedValue({
+    data: MOCK_RESERVATION,
+  });
+  vi.mocked(menuService.getMenuItems).mockResolvedValue({
+    data: MOCK_MENU_ITEMS,
+    meta: { current_page: 1, last_page: 1, per_page: 15, total: 3 },
+  });
+  vi.mocked(preOrderService.getItems).mockResolvedValue({
+    data: MOCK_PRE_ORDER_ITEMS,
+  });
+}
+
+function renderPage() {
+  return render(
+    <MemoryRouter>
+      <PreOrderPage />
+    </MemoryRouter>,
+  );
+}
+
+describe("PreOrderPage", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it("shows loading state initially", () => {
+    vi.mocked(reservationService.getById).mockReturnValue(new Promise(() => {}));
+    renderPage();
+
+    expect(screen.getByText("Cargando...")).toBeInTheDocument();
+  });
+
+  it("renders reservation summary after fetch", async () => {
+    mockDefaultServices();
+    renderPage();
+
+    await waitFor(() => {
+      expect(screen.getByText("10/04/2026")).toBeInTheDocument();
+    });
+
+    expect(screen.getByText("19:00 - 21:00")).toBeInTheDocument();
+    expect(screen.getByText("4")).toBeInTheDocument();
+    expect(screen.getByText("Mesa 1")).toBeInTheDocument();
+  });
+
+  it("shows error when reservation is not confirmed", async () => {
+    vi.mocked(reservationService.getById).mockResolvedValue({
+      data: { ...MOCK_RESERVATION, status: "pending" },
+    });
+    renderPage();
+
+    await waitFor(() => {
+      expect(
+        screen.getByText("Esta reservacion no permite pre-ordenes."),
+      ).toBeInTheDocument();
+    });
+
+    expect(
+      screen.getByText("Volver a mis reservaciones"),
+    ).toBeInTheDocument();
+  });
+
+  it("shows error when reservation fetch fails", async () => {
+    vi.mocked(reservationService.getById).mockRejectedValue(
+      new Error("Error del servidor"),
+    );
+    renderPage();
+
+    await waitFor(() => {
+      expect(screen.getByText("Error del servidor")).toBeInTheDocument();
+    });
+  });
+
+  it("renders menu items grouped by category", async () => {
+    mockDefaultServices();
+    renderPage();
+
+    await waitFor(() => {
+      expect(screen.getAllByText("Ensalada Cesar").length).toBeGreaterThanOrEqual(1);
+    });
+
+    expect(screen.getByRole("heading", { name: "Entrantes" })).toBeInTheDocument();
+    expect(screen.getByText("Lomo Saltado")).toBeInTheDocument();
+    expect(screen.getByRole("heading", { name: "Principales" })).toBeInTheDocument();
+    expect(screen.getByText("Tiramisú")).toBeInTheDocument();
+    expect(screen.getByRole("heading", { name: "Postres" })).toBeInTheDocument();
+  });
+
+  it("filters menu by category", async () => {
+    mockDefaultServices();
+    renderPage();
+    const user = userEvent.setup();
+
+    await waitFor(() => {
+      expect(screen.getAllByText("Ensalada Cesar").length).toBeGreaterThanOrEqual(1);
+    });
+
+    vi.mocked(menuService.getMenuItems).mockResolvedValue({
+      data: [MOCK_MENU_ITEMS[0]],
+      meta: { current_page: 1, last_page: 1, per_page: 15, total: 1 },
+    });
+
+    await user.click(screen.getByRole("button", { name: "Entrantes" }));
+
+    await waitFor(() => {
+      expect(menuService.getMenuItems).toHaveBeenCalledWith("entrantes");
+    });
+  });
+
+  it("adds an item to the pre-order", async () => {
+    mockDefaultServices();
+
+    const newItem: ReservationItem = {
+      id: 101,
+      quantity: 1,
+      unit_price: "18.00",
+      subtotal: "18.00",
+      menu_item: { id: 20, name: "Lomo Saltado", category: "principales" },
+      created_at: "2026-04-09T11:00:00Z",
+    };
+
+    vi.mocked(preOrderService.addItem).mockResolvedValue({ data: newItem });
+
+    const updatedItems = [...MOCK_PRE_ORDER_ITEMS, newItem];
+    vi.mocked(preOrderService.getItems)
+      .mockResolvedValueOnce({ data: MOCK_PRE_ORDER_ITEMS })
+      .mockResolvedValueOnce({ data: updatedItems });
+
+    renderPage();
+    const user = userEvent.setup();
+
+    await waitFor(() => {
+      expect(screen.getAllByText("Ensalada Cesar").length).toBeGreaterThanOrEqual(1);
+    });
+
+    const addButtons = screen.getAllByRole("button", { name: "Agregar" });
+    const lomoButton = addButtons[1];
+
+    await user.click(lomoButton);
+
+    await waitFor(() => {
+      expect(preOrderService.addItem).toHaveBeenCalledWith(1, {
+        menu_item_id: 20,
+        quantity: 1,
+      });
+    });
+
+    await waitFor(() => {
+      expect(screen.getAllByText("Lomo Saltado").length).toBe(2);
+    });
+  });
+
+  it("removes an item from the pre-order", async () => {
+    mockDefaultServices();
+    vi.mocked(preOrderService.removeItem).mockResolvedValue(null);
+    vi.mocked(preOrderService.getItems)
+      .mockResolvedValueOnce({ data: MOCK_PRE_ORDER_ITEMS })
+      .mockResolvedValueOnce({ data: [] });
+
+    renderPage();
+    const user = userEvent.setup();
+
+    await waitFor(() => {
+      expect(screen.getByText("Eliminar")).toBeInTheDocument();
+    });
+
+    await user.click(screen.getByRole("button", { name: "Eliminar" }));
+
+    await waitFor(() => {
+      expect(preOrderService.removeItem).toHaveBeenCalledWith(1, 100);
+    });
+
+    await waitFor(() => {
+      expect(
+        screen.getByText("No has agregado items aun."),
+      ).toBeInTheDocument();
+    });
+  });
+
+  it("shows subtotals and grand total", async () => {
+    mockDefaultServices();
+    renderPage();
+
+    await waitFor(() => {
+      expect(screen.getByText("2 x $8.50")).toBeInTheDocument();
+    });
+
+    const amounts = screen.getAllByText("$17.00");
+    expect(amounts).toHaveLength(2);
+    expect(screen.getByText("Total")).toBeInTheDocument();
+  });
+
+  it("shows error on add failure and can dismiss it", async () => {
+    mockDefaultServices();
+    vi.mocked(preOrderService.addItem).mockRejectedValue(
+      new Error("Stock insuficiente"),
+    );
+    renderPage();
+    const user = userEvent.setup();
+
+    await waitFor(() => {
+      expect(screen.getAllByText("Ensalada Cesar").length).toBeGreaterThanOrEqual(1);
+    });
+
+    const addButtons = screen.getAllByRole("button", { name: "Agregar" });
+    await user.click(addButtons[0]);
+
+    await waitFor(() => {
+      expect(screen.getByText("Stock insuficiente")).toBeInTheDocument();
+    });
+
+    await user.click(screen.getByRole("button", { name: "Cerrar" }));
+
+    expect(screen.queryByText("Stock insuficiente")).not.toBeInTheDocument();
+  });
+
+  it("shows error on remove failure", async () => {
+    mockDefaultServices();
+    vi.mocked(preOrderService.removeItem).mockRejectedValue(
+      new Error("Error al eliminar"),
+    );
+    renderPage();
+    const user = userEvent.setup();
+
+    await waitFor(() => {
+      expect(screen.getByText("Eliminar")).toBeInTheDocument();
+    });
+
+    await user.click(screen.getByRole("button", { name: "Eliminar" }));
+
+    await waitFor(() => {
+      expect(screen.getByText("Error al eliminar")).toBeInTheDocument();
+    });
+  });
+
+  it("disables add button for unavailable items", async () => {
+    mockDefaultServices();
+    renderPage();
+
+    await waitFor(() => {
+      expect(screen.getAllByText("Ensalada Cesar").length).toBeGreaterThanOrEqual(1);
+    });
+
+    expect(screen.getByText("Tiramisú")).toBeInTheDocument();
+    expect(screen.getByText("No disponible")).toBeInTheDocument();
+
+    const addButtons = screen.getAllByRole("button", { name: "Agregar" });
+    const tiramisuButton = addButtons[2];
+    expect(tiramisuButton).toBeDisabled();
+  });
+});

--- a/src/routes/Router.tsx
+++ b/src/routes/Router.tsx
@@ -12,6 +12,7 @@ import MenuPage from "../pages/MenuPage";
 import NewReservationPage from "../pages/NewReservationPage";
 import PaymentPage from "../pages/PaymentPage";
 import MyReservationsPage from "../pages/MyReservationsPage";
+import PreOrderPage from "../pages/PreOrderPage";
 
 // Placeholder components until real pages are built
 function Placeholder({ name }: { name: string }) {
@@ -57,7 +58,7 @@ export default function Router() {
               />
               <Route
                 path="/my-reservations/:id/pre-order"
-                element={<Placeholder name="Pre-order" />}
+                element={<PreOrderPage />}
               />
             </Route>
           </Route>


### PR DESCRIPTION
## Summary
- Add `MenuBrowser` component with category filters, quantity input, and add button per menu item
- Add `PreOrderSummary` component with item list, subtotals, grand total, and remove action
- Add `PreOrderPage` orchestrator that loads reservation details, menu items, and pre-order state
- Guard against non-confirmed reservations with error message and back link
- Replace pre-order placeholder route with actual page in Router

## Test plan
- [x] Shows loading state while fetching reservation
- [x] Renders reservation summary header (date, time, seats, table)
- [x] Shows error when reservation is not confirmed
- [x] Shows error when reservation fetch fails
- [x] Renders menu items grouped by category
- [x] Category filter triggers menu re-fetch
- [x] Adding item calls API and refreshes pre-order list
- [x] Removing item calls API and refreshes pre-order list
- [x] Shows subtotals per item and grand total
- [x] Error on add/remove is dismissible
- [x] Unavailable items show "No disponible" with disabled button
- [x] All 84 tests pass

Closes #13