### PR TITLE
Complete Account screen

### DIFF
--- a/src/pages/CompleteAccountPage.tsx
+++ b/src/pages/CompleteAccountPage.tsx
@@ -1,0 +1,69 @@
+import { useForm } from "react-hook-form";
+import { useNavigate } from "react-router-dom";
+import AuthFormWrapper from "../components/AuthFormWrapper";
+import FormField from "../components/FormField";
+import SubmitButton from "../components/SubmitButton";
+import { useAuth } from "../context/AuthContext";
+import { handleApiError } from "../lib/form-errors";
+import * as authService from "../services/auth.service";
+
+interface CompleteAccountForm {
+  password: string;
+  password_confirmation: string;
+}
+
+const FIELDS: (keyof CompleteAccountForm)[] = [
+  "password",
+  "password_confirmation",
+];
+
+export default function CompleteAccountPage() {
+  const navigate = useNavigate();
+  const { setSession } = useAuth();
+
+  const {
+    register,
+    handleSubmit,
+    setError,
+    formState: { errors, isSubmitting },
+  } = useForm<CompleteAccountForm>();
+
+  const onSubmit = async (data: CompleteAccountForm) => {
+    try {
+      const response = await authService.completeAccount(data);
+      const { user, token } = response.data;
+      setSession(user, token);
+      navigate("/my-reservations");
+    } catch (error) {
+      handleApiError<CompleteAccountForm>(error, setError, FIELDS);
+    }
+  };
+
+  return (
+    <AuthFormWrapper title="Completar cuenta" error={errors.root?.message}>
+      <form onSubmit={handleSubmit(onSubmit)} className="flex flex-col gap-4">
+        <FormField<CompleteAccountForm>
+          label="Contrasena"
+          name="password"
+          type="password"
+          register={register}
+          errors={errors}
+        />
+
+        <FormField<CompleteAccountForm>
+          label="Confirmar contrasena"
+          name="password_confirmation"
+          type="password"
+          register={register}
+          errors={errors}
+        />
+
+        <SubmitButton
+          label="Completar cuenta"
+          loadingLabel="Guardando..."
+          isSubmitting={isSubmitting}
+        />
+      </form>
+    </AuthFormWrapper>
+  );
+}

--- a/src/pages/__tests__/CompleteAccountPage.test.tsx
+++ b/src/pages/__tests__/CompleteAccountPage.test.tsx
@@ -1,0 +1,122 @@
+import { render, screen, waitFor } from "@testing-library/react";
+import userEvent from "@testing-library/user-event";
+import { MemoryRouter } from "react-router-dom";
+import CompleteAccountPage from "../CompleteAccountPage";
+import * as authService from "../../services/auth.service";
+import { ApiValidationError } from "../../lib/api";
+
+vi.mock("../../services/auth.service");
+
+const mockNavigate = vi.fn();
+const mockSetSession = vi.fn();
+
+vi.mock("react-router-dom", async () => {
+  const actual = await vi.importActual("react-router-dom");
+  return { ...actual, useNavigate: () => mockNavigate };
+});
+
+vi.mock("../../context/AuthContext", () => ({
+  useAuth: () => ({
+    user: { id: 1, name: "Guest", email: "guest@test.com", role: "client" },
+    isAuthenticated: true,
+    login: vi.fn(),
+    register: vi.fn(),
+    logout: vi.fn(),
+    setSession: mockSetSession,
+  }),
+}));
+
+function renderPage() {
+  return render(
+    <MemoryRouter>
+      <CompleteAccountPage />
+    </MemoryRouter>,
+  );
+}
+
+describe("CompleteAccountPage", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it("renders password fields and submit button", () => {
+    renderPage();
+
+    expect(screen.getByLabelText("Contrasena")).toBeInTheDocument();
+    expect(screen.getByLabelText("Confirmar contrasena")).toBeInTheDocument();
+    expect(
+      screen.getByRole("button", { name: "Completar cuenta" }),
+    ).toBeInTheDocument();
+  });
+
+  it("submits successfully, calls setSession and navigates to /my-reservations", async () => {
+    vi.mocked(authService.completeAccount).mockResolvedValue({
+      data: {
+        user: { id: 1, name: "Guest", email: "guest@test.com", role: "client" },
+        token: "new-token-123",
+      },
+    });
+    renderPage();
+    const user = userEvent.setup();
+
+    await user.type(screen.getByLabelText("Contrasena"), "mypassword");
+    await user.type(
+      screen.getByLabelText("Confirmar contrasena"),
+      "mypassword",
+    );
+    await user.click(
+      screen.getByRole("button", { name: "Completar cuenta" }),
+    );
+
+    await waitFor(() => {
+      expect(authService.completeAccount).toHaveBeenCalledWith({
+        password: "mypassword",
+        password_confirmation: "mypassword",
+      });
+      expect(mockSetSession).toHaveBeenCalledWith(
+        { id: 1, name: "Guest", email: "guest@test.com", role: "client" },
+        "new-token-123",
+      );
+      expect(mockNavigate).toHaveBeenCalledWith("/my-reservations");
+    });
+  });
+
+  it("displays field errors on 422 validation error", async () => {
+    vi.mocked(authService.completeAccount).mockRejectedValue(
+      new ApiValidationError({
+        message: "Validation failed",
+        errors: {
+          password: ["La contrasena debe tener al menos 8 caracteres"],
+        },
+      }),
+    );
+    renderPage();
+    const user = userEvent.setup();
+
+    await user.click(
+      screen.getByRole("button", { name: "Completar cuenta" }),
+    );
+
+    await waitFor(() => {
+      expect(
+        screen.getByText("La contrasena debe tener al menos 8 caracteres"),
+      ).toBeInTheDocument();
+    });
+  });
+
+  it("displays generic error for non-validation failures", async () => {
+    vi.mocked(authService.completeAccount).mockRejectedValue(
+      new Error("Error del servidor"),
+    );
+    renderPage();
+    const user = userEvent.setup();
+
+    await user.click(
+      screen.getByRole("button", { name: "Completar cuenta" }),
+    );
+
+    await waitFor(() => {
+      expect(screen.getByText("Error del servidor")).toBeInTheDocument();
+    });
+  });
+});

--- a/src/routes/Router.tsx
+++ b/src/routes/Router.tsx
@@ -13,11 +13,7 @@ import NewReservationPage from "../pages/NewReservationPage";
 import PaymentPage from "../pages/PaymentPage";
 import MyReservationsPage from "../pages/MyReservationsPage";
 import PreOrderPage from "../pages/PreOrderPage";
-
-// Placeholder components until real pages are built
-function Placeholder({ name }: { name: string }) {
-  return <h1>{name}</h1>;
-}
+import CompleteAccountPage from "../pages/CompleteAccountPage";
 
 export default function Router() {
   return (
@@ -47,7 +43,7 @@ export default function Router() {
             <Route path="/payment" element={<PaymentPage />} />
             <Route
               path="/complete-account"
-              element={<Placeholder name="Complete Account" />}
+              element={<CompleteAccountPage />}
             />
 
             {/* Protected routes */}


### PR DESCRIPTION
## Summary
- Add `CompleteAccountPage` with password and confirmation form for guest users to claim their account
- On success, update auth session via `setSession` and redirect to `/my-reservations`
- Handle 422 validation errors inline per field and generic errors via root message
- Replace route placeholder with actual page and remove unused `Placeholder` component from Router

## Test plan
- [x] Renders password and confirmation fields with submit button
- [x] Submits successfully, calls `setSession` with user/token, navigates to `/my-reservations`
- [x] Shows field-level errors on 422 validation failure
- [x] Shows generic error for non-validation failures
- [x] All 88 tests pass

Closes #15