### PR TITLE
Dynamic time slots from backend settings

### DIFF
--- a/api.json
+++ b/api.json
@@ -547,6 +547,13 @@
                         "schema": {
                             "$ref": "#/components/schemas/MenuCategory"
                         }
+                    },
+                    {
+                        "name": "featured",
+                        "in": "query",
+                        "schema": {
+                            "type": "boolean"
+                        }
                     }
                 ],
                 "responses": {
@@ -589,6 +596,13 @@
                         "in": "query",
                         "schema": {
                             "$ref": "#/components/schemas/MenuCategory"
+                        }
+                    },
+                    {
+                        "name": "featured",
+                        "in": "query",
+                        "schema": {
+                            "type": "boolean"
                         }
                     }
                 ],
@@ -941,6 +955,151 @@
                     },
                     "401": {
                         "$ref": "#/components/responses/AuthenticationException"
+                    }
+                }
+            }
+        },
+        "/profile": {
+            "get": {
+                "operationId": "profile.show",
+                "tags": [
+                    "Profile"
+                ],
+                "responses": {
+                    "200": {
+                        "description": "`UserResource`",
+                        "content": {
+                            "application/json": {
+                                "schema": {
+                                    "type": "object",
+                                    "properties": {
+                                        "data": {
+                                            "$ref": "#/components/schemas/UserResource"
+                                        }
+                                    },
+                                    "required": [
+                                        "data"
+                                    ]
+                                }
+                            }
+                        }
+                    },
+                    "401": {
+                        "$ref": "#/components/responses/AuthenticationException"
+                    }
+                }
+            },
+            "put": {
+                "operationId": "profile.update",
+                "tags": [
+                    "Profile"
+                ],
+                "requestBody": {
+                    "content": {
+                        "application/json": {
+                            "schema": {
+                                "$ref": "#/components/schemas/UpdateProfileRequest"
+                            }
+                        }
+                    }
+                },
+                "responses": {
+                    "200": {
+                        "description": "`UserResource`",
+                        "content": {
+                            "application/json": {
+                                "schema": {
+                                    "type": "object",
+                                    "properties": {
+                                        "data": {
+                                            "$ref": "#/components/schemas/UserResource"
+                                        }
+                                    },
+                                    "required": [
+                                        "data"
+                                    ]
+                                }
+                            }
+                        }
+                    },
+                    "401": {
+                        "$ref": "#/components/responses/AuthenticationException"
+                    },
+                    "422": {
+                        "$ref": "#/components/responses/ValidationException"
+                    }
+                }
+            }
+        },
+        "/profile/password": {
+            "put": {
+                "operationId": "profile.updatePassword",
+                "tags": [
+                    "Profile"
+                ],
+                "requestBody": {
+                    "required": true,
+                    "content": {
+                        "application/json": {
+                            "schema": {
+                                "$ref": "#/components/schemas/UpdatePasswordRequest"
+                            }
+                        }
+                    }
+                },
+                "responses": {
+                    "200": {
+                        "description": "",
+                        "content": {
+                            "application/json": {
+                                "schema": {
+                                    "type": "object",
+                                    "properties": {
+                                        "message": {
+                                            "type": "string",
+                                            "const": "Contrasena actualizada correctamente."
+                                        }
+                                    },
+                                    "required": [
+                                        "message"
+                                    ]
+                                }
+                            }
+                        }
+                    },
+                    "401": {
+                        "$ref": "#/components/responses/AuthenticationException"
+                    },
+                    "422": {
+                        "$ref": "#/components/responses/ValidationException"
+                    }
+                }
+            }
+        },
+        "/settings/public": {
+            "get": {
+                "operationId": "publicSetting",
+                "tags": [
+                    "PublicSetting"
+                ],
+                "responses": {
+                    "200": {
+                        "description": "`PublicRestaurantSettingResource`",
+                        "content": {
+                            "application/json": {
+                                "schema": {
+                                    "type": "object",
+                                    "properties": {
+                                        "data": {
+                                            "$ref": "#/components/schemas/PublicRestaurantSettingResource"
+                                        }
+                                    },
+                                    "required": [
+                                        "data"
+                                    ]
+                                }
+                            }
+                        }
                     }
                 }
             }
@@ -1777,6 +1936,9 @@
                     "is_available": {
                         "type": "boolean"
                     },
+                    "is_featured": {
+                        "type": "boolean"
+                    },
                     "daily_stock": {
                         "type": [
                             "integer",
@@ -1794,9 +1956,30 @@
                     "price",
                     "category",
                     "is_available",
+                    "is_featured",
                     "created_at"
                 ],
                 "title": "MenuItemResource"
+            },
+            "PublicRestaurantSettingResource": {
+                "type": "object",
+                "properties": {
+                    "opening_time": {
+                        "type": "string"
+                    },
+                    "closing_time": {
+                        "type": "string"
+                    },
+                    "time_slot_interval_minutes": {
+                        "type": "string"
+                    }
+                },
+                "required": [
+                    "opening_time",
+                    "closing_time",
+                    "time_slot_interval_minutes"
+                ],
+                "title": "PublicRestaurantSettingResource"
             },
             "RegisterRequest": {
                 "type": "object",
@@ -1983,6 +2166,12 @@
                     },
                     "time_slot_interval_minutes": {
                         "type": "integer"
+                    },
+                    "opening_time": {
+                        "type": "string"
+                    },
+                    "closing_time": {
+                        "type": "string"
                     }
                 },
                 "required": [
@@ -1991,7 +2180,9 @@
                     "refund_percentage",
                     "default_reservation_duration_minutes",
                     "reminder_hours_before",
-                    "time_slot_interval_minutes"
+                    "time_slot_interval_minutes",
+                    "opening_time",
+                    "closing_time"
                 ],
                 "title": "RestaurantSettingResource"
             },
@@ -2128,6 +2319,48 @@
                 },
                 "title": "UpdateMenuItemRequest"
             },
+            "UpdatePasswordRequest": {
+                "type": "object",
+                "properties": {
+                    "current_password": {
+                        "type": "string"
+                    },
+                    "password": {
+                        "type": "string"
+                    },
+                    "password_confirmation": {
+                        "type": "string"
+                    }
+                },
+                "required": [
+                    "current_password",
+                    "password",
+                    "password_confirmation"
+                ],
+                "title": "UpdatePasswordRequest"
+            },
+            "UpdateProfileRequest": {
+                "type": "object",
+                "properties": {
+                    "name": {
+                        "type": "string",
+                        "maxLength": 255
+                    },
+                    "email": {
+                        "type": "string",
+                        "format": "email",
+                        "maxLength": 255
+                    },
+                    "phone": {
+                        "type": [
+                            "string",
+                            "null"
+                        ],
+                        "maxLength": 20
+                    }
+                },
+                "title": "UpdateProfileRequest"
+            },
             "UpdateRestaurantSettingRequest": {
                 "type": "object",
                 "properties": {
@@ -2163,6 +2396,12 @@
                             "45",
                             "60"
                         ]
+                    },
+                    "opening_time": {
+                        "type": "string"
+                    },
+                    "closing_time": {
+                        "type": "string"
                     }
                 },
                 "title": "UpdateRestaurantSettingRequest"
@@ -2210,13 +2449,21 @@
                     "email": {
                         "type": "string"
                     },
-                    "role": {}
+                    "phone": {
+                        "type": "string"
+                    },
+                    "role": {},
+                    "is_guest": {
+                        "type": "boolean"
+                    }
                 },
                 "required": [
                     "id",
                     "name",
                     "email",
-                    "role"
+                    "phone",
+                    "role",
+                    "is_guest"
                 ],
                 "title": "UserResource"
             }

--- a/src/pages/NewReservationPage.tsx
+++ b/src/pages/NewReservationPage.tsx
@@ -1,13 +1,14 @@
-import { useState } from "react";
+import { useEffect, useState } from "react";
 import { useForm } from "react-hook-form";
 import { useNavigate } from "react-router-dom";
 import FormField from "../components/FormField";
 import SubmitButton from "../components/SubmitButton";
 import { useAuth } from "../context/AuthContext";
 import { handleApiError } from "../lib/form-errors";
-import type { Reservation, Table } from "../types/api";
+import type { PublicSettings, Reservation, Table } from "../types/api";
 import * as reservationService from "../services/reservation.service";
 import * as guestService from "../services/guest.service";
+import * as settingsService from "../services/settings.service";
 
 function formatDate(date: Date): string {
   const year = date.getFullYear();
@@ -16,18 +17,20 @@ function formatDate(date: Date): string {
   return `${year}-${month}-${day}`;
 }
 
-function generateTimeSlots(): string[] {
+function generateTimeSlots(opening: string, closing: string, intervalMinutes: number): string[] {
+  const [openH, openM] = opening.split(":").map(Number);
+  const [closeH, closeM] = closing.split(":").map(Number);
+  const startMinutes = openH * 60 + openM;
+  const endMinutes = closeH * 60 + closeM;
+
   const slots: string[] = [];
-  for (let hour = 13; hour <= 23; hour++) {
-    slots.push(`${String(hour).padStart(2, "0")}:00`);
-    if (hour < 23) {
-      slots.push(`${String(hour).padStart(2, "0")}:30`);
-    }
+  for (let m = startMinutes; m <= endMinutes; m += intervalMinutes) {
+    const h = Math.floor(m / 60);
+    const min = m % 60;
+    slots.push(`${String(h).padStart(2, "0")}:${String(min).padStart(2, "0")}`);
   }
   return slots;
 }
-
-const TIME_SLOTS = generateTimeSlots();
 
 interface GuestForm {
   name: string;
@@ -56,18 +59,42 @@ export default function NewReservationPage() {
   const minDateStr = formatDate(today);
   const maxDateStr = formatDate(maxDate);
 
+  const [settings, setSettings] = useState<PublicSettings | null>(null);
+  const [isSettingsLoading, setIsSettingsLoading] = useState(true);
+  const [settingsError, setSettingsError] = useState("");
+
+  useEffect(() => {
+    settingsService
+      .getPublicSettings()
+      .then((response) => setSettings(response.data))
+      .catch((err: unknown) => {
+        const message =
+          err instanceof Error ? err.message : "Error al cargar la configuracion";
+        setSettingsError(message);
+      })
+      .finally(() => setIsSettingsLoading(false));
+  }, []);
+
   const [step, setStep] = useState(1);
   const [date, setDate] = useState("");
   const [startTime, setStartTime] = useState("");
 
+  const timeSlots = settings
+    ? generateTimeSlots(
+        settings.opening_time,
+        settings.closing_time,
+        Number(settings.time_slot_interval_minutes),
+      )
+    : [];
+
   const isToday = date === minDateStr;
   const availableSlots = isToday
-    ? TIME_SLOTS.filter((slot) => {
+    ? timeSlots.filter((slot) => {
         const now = new Date();
         const [h, m] = slot.split(":").map(Number);
         return h > now.getHours() || (h === now.getHours() && m > now.getMinutes());
       })
-    : TIME_SLOTS;
+    : timeSlots;
 
   const handleDateChange = (newDate: string) => {
     setDate(newDate);
@@ -148,7 +175,7 @@ export default function NewReservationPage() {
         start_time: startTime,
       });
       navigateToPayment(
-        response.data.payment_intent_client_secret,
+        response.data.client_secret,
         response.data.reservation,
       );
     } catch (err: unknown) {
@@ -174,7 +201,7 @@ export default function NewReservationPage() {
         start_time: startTime,
       });
       navigateToPayment(
-        response.data.payment_intent_client_secret,
+        response.data.client_secret,
         response.data.reservation,
       );
     } catch (err) {
@@ -240,13 +267,27 @@ export default function NewReservationPage() {
         })}
       </div>
 
+      {isSettingsLoading && (
+        <div className="mt-6 space-y-4">
+          {[1, 2, 3].map((i) => (
+            <div key={i} className="h-10 animate-pulse rounded-sm bg-zinc-700" />
+          ))}
+        </div>
+      )}
+
+      {settingsError && (
+        <p className="mt-4 rounded-sm bg-red-900/30 p-3 text-sm text-red-400">
+          {settingsError}
+        </p>
+      )}
+
       {error && (
         <p className="mt-4 rounded-sm bg-red-900/30 p-3 text-sm text-red-400">
           {error}
         </p>
       )}
 
-      {step === 1 && (
+      {!isSettingsLoading && !settingsError && step === 1 && (
         <form
           onSubmit={(e) => {
             e.preventDefault();

--- a/src/pages/__tests__/NewReservationPage.test.tsx
+++ b/src/pages/__tests__/NewReservationPage.test.tsx
@@ -4,11 +4,13 @@ import { MemoryRouter } from "react-router-dom";
 import NewReservationPage from "../NewReservationPage";
 import * as reservationService from "../../services/reservation.service";
 import * as guestService from "../../services/guest.service";
+import * as settingsService from "../../services/settings.service";
 import { ApiValidationError } from "../../lib/api";
 import type { Table } from "../../types/api";
 
 vi.mock("../../services/reservation.service");
 vi.mock("../../services/guest.service");
+vi.mock("../../services/settings.service");
 
 const mockNavigate = vi.fn();
 
@@ -83,7 +85,7 @@ function mockCreateHold() {
   vi.mocked(reservationService.createHold).mockResolvedValue({
     data: {
       reservation: MOCK_HOLD_RESERVATION,
-      payment_intent_client_secret: "pi_secret_123",
+      client_secret: "pi_secret_123",
     },
   });
 }
@@ -92,17 +94,30 @@ function mockCreateGuestReservation() {
   vi.mocked(guestService.createGuestReservation).mockResolvedValue({
     data: {
       reservation: MOCK_GUEST_RESERVATION,
-      payment_intent_client_secret: "pi_secret_456",
+      client_secret: "pi_secret_456",
     },
   });
 }
 
-function renderPage() {
-  return render(
+function mockGetPublicSettings() {
+  vi.mocked(settingsService.getPublicSettings).mockResolvedValue({
+    data: {
+      opening_time: "13:00",
+      closing_time: "23:00",
+      time_slot_interval_minutes: "30",
+    },
+  });
+}
+
+async function renderPage() {
+  render(
     <MemoryRouter>
       <NewReservationPage />
     </MemoryRouter>,
   );
+  await waitFor(() => {
+    expect(screen.getByLabelText("Fecha")).toBeInTheDocument();
+  });
 }
 
 async function fillSearchAndSubmit(user: ReturnType<typeof userEvent.setup>) {
@@ -129,11 +144,12 @@ describe("NewReservationPage", () => {
   beforeEach(() => {
     vi.clearAllMocks();
     mockIsAuthenticated = false;
+    mockGetPublicSettings();
   });
 
   describe("Step 1 - Search", () => {
-    it("renders search form with date, time, and seats fields", () => {
-      renderPage();
+    it("renders search form with date, time, and seats fields", async () => {
+      await renderPage();
 
       expect(screen.getByLabelText("Fecha")).toBeInTheDocument();
       expect(screen.getByText("Hora")).toBeInTheDocument();
@@ -143,8 +159,8 @@ describe("NewReservationPage", () => {
       ).toBeInTheDocument();
     });
 
-    it("renders step indicators", () => {
-      renderPage();
+    it("renders step indicators", async () => {
+      await renderPage();
 
       expect(screen.getByText("Buscar")).toBeInTheDocument();
       expect(screen.getByText("Elegir mesa")).toBeInTheDocument();
@@ -153,7 +169,7 @@ describe("NewReservationPage", () => {
 
     it("calls getAvailableTables and moves to step 2", async () => {
       mockAvailableTables();
-      renderPage();
+      await renderPage();
       const user = userEvent.setup();
 
       await fillSearchAndSubmit(user);
@@ -174,7 +190,7 @@ describe("NewReservationPage", () => {
 
     it("shows error when no tables are available", async () => {
       mockAvailableTables([]);
-      renderPage();
+      await renderPage();
       const user = userEvent.setup();
 
       await fillSearchAndSubmit(user);
@@ -192,7 +208,7 @@ describe("NewReservationPage", () => {
       vi.mocked(reservationService.getAvailableTables).mockRejectedValue(
         new Error("Error del servidor"),
       );
-      renderPage();
+      await renderPage();
       const user = userEvent.setup();
 
       await fillSearchAndSubmit(user);
@@ -206,7 +222,7 @@ describe("NewReservationPage", () => {
   describe("Step 2 - Table selection", () => {
     async function goToStep2() {
       mockAvailableTables();
-      renderPage();
+      await renderPage();
       const user = userEvent.setup();
       await fillSearchAndSubmit(user);
       await waitFor(() => {
@@ -256,7 +272,7 @@ describe("NewReservationPage", () => {
     async function goToStep3Registered() {
       mockIsAuthenticated = true;
       mockAvailableTables();
-      renderPage();
+      await renderPage();
       const user = userEvent.setup();
 
       await fillSearchAndSubmit(user);
@@ -323,7 +339,7 @@ describe("NewReservationPage", () => {
     async function goToStep3Guest() {
       mockIsAuthenticated = false;
       mockAvailableTables();
-      renderPage();
+      await renderPage();
       const user = userEvent.setup();
 
       await fillSearchAndSubmit(user);

--- a/src/services/guest.service.ts
+++ b/src/services/guest.service.ts
@@ -13,7 +13,7 @@ interface GuestReservationBody {
 
 interface GuestReservationResponse {
   reservation: Reservation;
-  payment_intent_client_secret: string;
+  client_secret: string;
 }
 
 export function createGuestReservation(body: GuestReservationBody) {

--- a/src/services/reservation.service.ts
+++ b/src/services/reservation.service.ts
@@ -15,7 +15,7 @@ interface HoldReservationBody {
 
 interface HoldReservationResponse {
   reservation: Reservation;
-  payment_intent_client_secret: string;
+  client_secret: string;
 }
 
 interface AvailableTablesParams {

--- a/src/services/settings.service.ts
+++ b/src/services/settings.service.ts
@@ -1,0 +1,6 @@
+import { apiFetch } from "../lib/api";
+import type { ApiResponse, PublicSettings } from "../types/api";
+
+export function getPublicSettings() {
+  return apiFetch<ApiResponse<PublicSettings>>("/settings/public");
+}

--- a/src/types/api.ts
+++ b/src/types/api.ts
@@ -76,6 +76,12 @@ export interface ReservationItem {
   created_at: string;
 }
 
+export interface PublicSettings {
+  opening_time: string;
+  closing_time: string;
+  time_slot_interval_minutes: string;
+}
+
 // --- API response wrappers ---
 
 export interface ApiResponse<T> {


### PR DESCRIPTION
## Summary

- Fetch `opening_time`, `closing_time`, and `time_slot_interval_minutes` from `GET /api/settings/public` to generate reservation time slots dynamically
- Add `PublicSettings` type and `settings.service.ts` for the new endpoint
- Show skeleton loading state while settings are fetched, error state on failure
- Rename `payment_intent_client_secret` to `client_secret` across services, pages, and tests
- Update `api.json` with new backend endpoints (settings/public, profile, featured items)

## Test plan

- [x] All 88 tests pass (`npx vitest run`)
- [x] Build succeeds with no TypeScript errors (`npm run build`)
- [ ] Manual: start dev server, navigate to /reservations/new, verify time slots load from backend
- [ ] Manual: verify skeleton appears briefly while settings load
- [ ] Manual: verify "today" filtering still hides past time slots

Closes #19