### PR TITLE
Fix auth bugs: email_confirmation in register and complete-account response

### DIFF
--- a/src/context/AuthContext.tsx
+++ b/src/context/AuthContext.tsx
@@ -39,12 +39,14 @@ interface AuthContextValue {
   register: (body: {
     name: string;
     email: string;
+    email_confirmation: string;
     phone: string;
     password: string;
     password_confirmation: string;
   }) => Promise<void>;
   logout: () => Promise<void>;
   setSession: (user: User, token: string) => void;
+  updateUser: (user: User) => void;
 }
 
 const AuthContext = createContext<AuthContextValue | null>(null);
@@ -72,10 +74,16 @@ export function AuthProvider({ children }: { children: ReactNode }) {
     [saveSession],
   );
 
+  const updateUser = useCallback((user: User) => {
+    setStoredUser(user);
+    setUser(user);
+  }, []);
+
   const register = useCallback(
     async (body: {
       name: string;
       email: string;
+      email_confirmation: string;
       phone: string;
       password: string;
       password_confirmation: string;
@@ -102,8 +110,9 @@ export function AuthProvider({ children }: { children: ReactNode }) {
       register,
       logout,
       setSession: saveSession,
+      updateUser,
     }),
-    [user, login, register, logout, saveSession],
+    [user, login, register, logout, saveSession, updateUser],
   );
 
   return <AuthContext.Provider value={value}>{children}</AuthContext.Provider>;

--- a/src/pages/CompleteAccountPage.tsx
+++ b/src/pages/CompleteAccountPage.tsx
@@ -19,7 +19,7 @@ const FIELDS: (keyof CompleteAccountForm)[] = [
 
 export default function CompleteAccountPage() {
   const navigate = useNavigate();
-  const { setSession } = useAuth();
+  const { updateUser } = useAuth();
 
   const {
     register,
@@ -31,8 +31,7 @@ export default function CompleteAccountPage() {
   const onSubmit = async (data: CompleteAccountForm) => {
     try {
       const response = await authService.completeAccount(data);
-      const { user, token } = response.data;
-      setSession(user, token);
+      updateUser(response.data);
       navigate("/my-reservations");
     } catch (error) {
       handleApiError<CompleteAccountForm>(error, setError, FIELDS);

--- a/src/pages/RegisterPage.tsx
+++ b/src/pages/RegisterPage.tsx
@@ -9,6 +9,7 @@ import { handleApiError } from "../lib/form-errors";
 interface RegisterForm {
   name: string;
   email: string;
+  email_confirmation: string;
   phone: string;
   password: string;
   password_confirmation: string;
@@ -17,6 +18,7 @@ interface RegisterForm {
 const FIELDS: (keyof RegisterForm)[] = [
   "name",
   "email",
+  "email_confirmation",
   "phone",
   "password",
   "password_confirmation",
@@ -54,6 +56,14 @@ export default function RegisterPage() {
         <FormField<RegisterForm>
           label="Correo electronico"
           name="email"
+          type="email"
+          register={register}
+          errors={errors}
+        />
+
+        <FormField<RegisterForm>
+          label="Confirmar correo electronico"
+          name="email_confirmation"
           type="email"
           register={register}
           errors={errors}

--- a/src/pages/__tests__/CompleteAccountPage.test.tsx
+++ b/src/pages/__tests__/CompleteAccountPage.test.tsx
@@ -8,7 +8,7 @@ import { ApiValidationError } from "../../lib/api";
 vi.mock("../../services/auth.service");
 
 const mockNavigate = vi.fn();
-const mockSetSession = vi.fn();
+const mockUpdateUser = vi.fn();
 
 vi.mock("react-router-dom", async () => {
   const actual = await vi.importActual("react-router-dom");
@@ -22,7 +22,8 @@ vi.mock("../../context/AuthContext", () => ({
     login: vi.fn(),
     register: vi.fn(),
     logout: vi.fn(),
-    setSession: mockSetSession,
+    setSession: vi.fn(),
+    updateUser: mockUpdateUser,
   }),
 }));
 
@@ -49,12 +50,9 @@ describe("CompleteAccountPage", () => {
     ).toBeInTheDocument();
   });
 
-  it("submits successfully, calls setSession and navigates to /my-reservations", async () => {
+  it("submits successfully, calls updateUser and navigates to /my-reservations", async () => {
     vi.mocked(authService.completeAccount).mockResolvedValue({
-      data: {
-        user: { id: 1, name: "Guest", email: "guest@test.com", role: "client" },
-        token: "new-token-123",
-      },
+      data: { id: 1, name: "Guest", email: "guest@test.com", phone: "612345678", role: "client", is_guest: false },
     });
     renderPage();
     const user = userEvent.setup();
@@ -73,9 +71,8 @@ describe("CompleteAccountPage", () => {
         password: "mypassword",
         password_confirmation: "mypassword",
       });
-      expect(mockSetSession).toHaveBeenCalledWith(
-        { id: 1, name: "Guest", email: "guest@test.com", role: "client" },
-        "new-token-123",
+      expect(mockUpdateUser).toHaveBeenCalledWith(
+        { id: 1, name: "Guest", email: "guest@test.com", phone: "612345678", role: "client", is_guest: false },
       );
       expect(mockNavigate).toHaveBeenCalledWith("/my-reservations");
     });

--- a/src/pages/__tests__/RegisterPage.test.tsx
+++ b/src/pages/__tests__/RegisterPage.test.tsx
@@ -41,6 +41,7 @@ describe("RegisterPage", () => {
 
     expect(screen.getByLabelText("Nombre")).toBeInTheDocument();
     expect(screen.getByLabelText("Correo electronico")).toBeInTheDocument();
+    expect(screen.getByLabelText("Confirmar correo electronico")).toBeInTheDocument();
     expect(screen.getByLabelText("Telefono")).toBeInTheDocument();
     expect(screen.getByLabelText("Contrasena")).toBeInTheDocument();
     expect(screen.getByLabelText("Confirmar contrasena")).toBeInTheDocument();
@@ -59,6 +60,10 @@ describe("RegisterPage", () => {
       screen.getByLabelText("Correo electronico"),
       "juan@email.com",
     );
+    await user.type(
+      screen.getByLabelText("Confirmar correo electronico"),
+      "juan@email.com",
+    );
     await user.type(screen.getByLabelText("Telefono"), "1234567890");
     await user.type(screen.getByLabelText("Contrasena"), "password123");
     await user.type(
@@ -71,6 +76,7 @@ describe("RegisterPage", () => {
       expect(mockRegister).toHaveBeenCalledWith({
         name: "Juan Perez",
         email: "juan@email.com",
+        email_confirmation: "juan@email.com",
         phone: "1234567890",
         password: "password123",
         password_confirmation: "password123",

--- a/src/services/auth.service.ts
+++ b/src/services/auth.service.ts
@@ -3,11 +3,13 @@ import type {
   ApiResponse,
   AuthResponse,
   MessageResponse,
+  User,
 } from "../types/api";
 
 interface RegisterBody {
   name: string;
   email: string;
+  email_confirmation: string;
   phone: string;
   password: string;
   password_confirmation: string;
@@ -65,7 +67,7 @@ export function resetPassword(body: ResetPasswordBody) {
 }
 
 export function completeAccount(body: CompleteAccountBody) {
-  return apiFetch<ApiResponse<AuthResponse>>("/auth/complete-account", {
+  return apiFetch<ApiResponse<User>>("/auth/complete-account", {
     method: "POST",
     body,
   });


### PR DESCRIPTION
## Summary
- Register form now sends `email_confirmation` field required by the API
- `completeAccount` handles new response format (`{ data: UserResource }` without token) via new `updateUser` method in AuthContext

Closes #21

## Test plan
- [ ] Register with matching email/email_confirmation succeeds
- [ ] Register with mismatched emails shows validation error
- [ ] Complete account flow updates user in context without losing existing token
- [ ] All 88 tests pass