### PR TITLE
Consume /reservations/time-slots endpoint and polish button UX

### DIFF
--- a/src/components/CancelModal.tsx
+++ b/src/components/CancelModal.tsx
@@ -48,7 +48,7 @@ export default function CancelModal({
             type="button"
             onClick={onClose}
             disabled={isSubmitting}
-            className="rounded-sm border border-zinc-600 px-4 py-2 text-sm font-medium text-zinc-400 hover:border-zinc-500 hover:text-white disabled:cursor-not-allowed disabled:opacity-50"
+            className="cursor-pointer rounded-sm border border-zinc-600 px-4 py-2 text-sm font-medium text-zinc-400 transition-colors duration-200 hover:border-zinc-500 hover:text-white disabled:cursor-not-allowed disabled:opacity-50"
           >
             Volver
           </button>
@@ -56,7 +56,7 @@ export default function CancelModal({
             type="button"
             onClick={onConfirm}
             disabled={isSubmitting}
-            className="rounded-sm bg-red-600 px-4 py-2 text-sm font-medium text-white hover:bg-red-500 disabled:cursor-not-allowed disabled:opacity-50"
+            className="cursor-pointer rounded-sm bg-red-600 px-4 py-2 text-sm font-medium text-white transition-colors duration-200 hover:bg-red-500 disabled:cursor-not-allowed disabled:opacity-50"
           >
             {isSubmitting ? "Cancelando..." : "Cancelar reservacion"}
           </button>

--- a/src/components/MenuBrowser.tsx
+++ b/src/components/MenuBrowser.tsx
@@ -57,7 +57,7 @@ function MenuItemCard({
           type="button"
           onClick={() => onAddItem(item.id, quantity)}
           disabled={!item.is_available || isAdding}
-          className="rounded-sm bg-amber-500 px-3 py-1 text-sm font-medium text-zinc-900 transition-colors duration-200 hover:bg-amber-400 disabled:opacity-50"
+          className="cursor-pointer rounded-sm bg-amber-500 px-3 py-1 text-sm font-medium text-zinc-900 transition-colors duration-200 hover:bg-amber-400 disabled:cursor-not-allowed disabled:opacity-50"
         >
           {isAdding ? "Agregando..." : "Agregar"}
         </button>

--- a/src/components/SubmitButton.tsx
+++ b/src/components/SubmitButton.tsx
@@ -13,7 +13,7 @@ export default function SubmitButton({
     <button
       type="submit"
       disabled={isSubmitting}
-      className="rounded-sm bg-amber-500 py-2.5 text-sm font-medium tracking-wide text-zinc-900
+      className="cursor-pointer rounded-sm bg-amber-500 py-2.5 text-sm font-medium tracking-wide text-zinc-900
         transition-colors duration-200 hover:bg-amber-600
         disabled:cursor-not-allowed disabled:opacity-50"
     >

--- a/src/pages/MyReservationsPage.tsx
+++ b/src/pages/MyReservationsPage.tsx
@@ -191,7 +191,7 @@ export default function MyReservationsPage() {
               <button
                 type="button"
                 onClick={() => toggleAccordion(reservation.id)}
-                className="flex w-full items-center justify-between px-6 py-4 text-left transition-colors duration-200 hover:bg-zinc-800"
+                className="flex w-full cursor-pointer items-center justify-between px-6 py-4 text-left transition-colors duration-200 hover:bg-zinc-800"
                 aria-expanded={isExpanded}
               >
                 <div className="flex items-center gap-4">
@@ -287,7 +287,7 @@ export default function MyReservationsPage() {
                           <button
                             type="button"
                             onClick={() => setCancellingId(detail.id)}
-                            className="rounded-sm border border-red-800 px-4 py-2 text-sm font-medium text-red-400 transition-colors duration-200 hover:bg-red-900/30"
+                            className="cursor-pointer rounded-sm border border-red-800 px-4 py-2 text-sm font-medium text-red-400 transition-colors duration-200 hover:bg-red-900/30"
                           >
                             Cancelar
                           </button>

--- a/src/pages/NewReservationPage.tsx
+++ b/src/pages/NewReservationPage.tsx
@@ -86,7 +86,6 @@ export default function NewReservationPage() {
 
   const searchTables = async () => {
     if (!date || !startTime || !seatsRequested) {
-      setError("Completa todos los campos para buscar mesas.");
       return;
     }
 
@@ -333,8 +332,8 @@ export default function NewReservationPage() {
 
           <button
             type="submit"
-            disabled={isLoading}
-            className="rounded-sm bg-amber-500 py-2.5 text-sm font-medium tracking-wide text-zinc-900
+            disabled={isLoading || !date || !startTime || !seatsRequested}
+            className="cursor-pointer rounded-sm bg-amber-500 py-2.5 text-sm font-medium tracking-wide text-zinc-900
               transition-colors duration-200 hover:bg-amber-600
               disabled:cursor-not-allowed disabled:opacity-50"
           >
@@ -357,7 +356,7 @@ export default function NewReservationPage() {
                 key={table.id}
                 type="button"
                 onClick={() => setSelectedTable(table)}
-                className={`rounded-sm border p-5 text-left transition-all duration-200 ${
+                className={`cursor-pointer rounded-sm border p-5 text-left transition-all duration-200 ${
                   selectedTable?.id === table.id
                     ? "border-amber-500 bg-amber-500/10 text-white"
                     : "border-zinc-700 text-zinc-200 hover:border-zinc-500"
@@ -381,7 +380,7 @@ export default function NewReservationPage() {
                 setSelectedTable(null);
                 setError("");
               }}
-              className="rounded-sm border border-zinc-700 px-4 py-2.5 text-sm
+              className="cursor-pointer rounded-sm border border-zinc-700 px-4 py-2.5 text-sm
                 font-medium text-zinc-400 transition-colors duration-200 hover:border-zinc-500 hover:text-white"
             >
               Volver
@@ -390,7 +389,7 @@ export default function NewReservationPage() {
               type="button"
               onClick={() => setStep(3)}
               disabled={!selectedTable}
-              className="rounded-sm bg-amber-500 px-4 py-2.5 text-sm font-medium tracking-wide text-zinc-900
+              className="cursor-pointer rounded-sm bg-amber-500 px-4 py-2.5 text-sm font-medium tracking-wide text-zinc-900
                 transition-colors duration-200 hover:bg-amber-400
                 disabled:cursor-not-allowed disabled:opacity-50"
             >
@@ -431,7 +430,7 @@ export default function NewReservationPage() {
               type="button"
               onClick={createRegisteredHold}
               disabled={isHoldSubmitting}
-              className="mt-6 w-full rounded-sm bg-amber-500 py-2.5 text-sm font-medium
+              className="mt-6 w-full cursor-pointer rounded-sm bg-amber-500 py-2.5 text-sm font-medium
                 tracking-wide text-zinc-900 transition-colors duration-200 hover:bg-amber-600
                 disabled:cursor-not-allowed disabled:opacity-50"
             >
@@ -489,7 +488,7 @@ export default function NewReservationPage() {
               setStep(2);
               setError("");
             }}
-            className="mt-3 w-full rounded-sm border border-zinc-700 py-2.5 text-sm
+            className="mt-3 w-full cursor-pointer rounded-sm border border-zinc-700 py-2.5 text-sm
               font-medium text-zinc-400 transition-colors duration-200 hover:border-zinc-500 hover:text-white"
           >
             Volver

--- a/src/pages/NewReservationPage.tsx
+++ b/src/pages/NewReservationPage.tsx
@@ -5,31 +5,15 @@ import FormField from "../components/FormField";
 import SubmitButton from "../components/SubmitButton";
 import { useAuth } from "../context/AuthContext";
 import { handleApiError } from "../lib/form-errors";
-import type { PublicSettings, Reservation, Table } from "../types/api";
+import type { Reservation, Table, TimeSlot } from "../types/api";
 import * as reservationService from "../services/reservation.service";
 import * as guestService from "../services/guest.service";
-import * as settingsService from "../services/settings.service";
 
 function formatDate(date: Date): string {
   const year = date.getFullYear();
   const month = String(date.getMonth() + 1).padStart(2, "0");
   const day = String(date.getDate()).padStart(2, "0");
   return `${year}-${month}-${day}`;
-}
-
-function generateTimeSlots(opening: string, closing: string, intervalMinutes: number): string[] {
-  const [openH, openM] = opening.split(":").map(Number);
-  const [closeH, closeM] = closing.split(":").map(Number);
-  const startMinutes = openH * 60 + openM;
-  const endMinutes = closeH * 60 + closeM;
-
-  const slots: string[] = [];
-  for (let m = startMinutes; m <= endMinutes; m += intervalMinutes) {
-    const h = Math.floor(m / 60);
-    const min = m % 60;
-    slots.push(`${String(h).padStart(2, "0")}:${String(min).padStart(2, "0")}`);
-  }
-  return slots;
 }
 
 interface GuestForm {
@@ -59,57 +43,34 @@ export default function NewReservationPage() {
   const minDateStr = formatDate(today);
   const maxDateStr = formatDate(maxDate);
 
-  const [settings, setSettings] = useState<PublicSettings | null>(null);
-  const [isSettingsLoading, setIsSettingsLoading] = useState(true);
-  const [settingsError, setSettingsError] = useState("");
-
-  useEffect(() => {
-    settingsService
-      .getPublicSettings()
-      .then((response) => setSettings(response.data))
-      .catch((err: unknown) => {
-        const message =
-          err instanceof Error ? err.message : "Error al cargar la configuracion";
-        setSettingsError(message);
-      })
-      .finally(() => setIsSettingsLoading(false));
-  }, []);
-
   const [step, setStep] = useState(1);
   const [date, setDate] = useState("");
   const [startTime, setStartTime] = useState("");
-
-  const timeSlots = settings
-    ? generateTimeSlots(
-        settings.opening_time,
-        settings.closing_time,
-        Number(settings.time_slot_interval_minutes),
-      )
-    : [];
-
-  const isToday = date === minDateStr;
-  const availableSlots = isToday
-    ? timeSlots.filter((slot) => {
-        const now = new Date();
-        const [h, m] = slot.split(":").map(Number);
-        return h > now.getHours() || (h === now.getHours() && m > now.getMinutes());
-      })
-    : timeSlots;
-
-  const handleDateChange = (newDate: string) => {
-    setDate(newDate);
-    if (newDate === minDateStr) {
-      const now = new Date();
-      const isSlotPast = (slot: string) => {
-        const [h, m] = slot.split(":").map(Number);
-        return h < now.getHours() || (h === now.getHours() && m <= now.getMinutes());
-      };
-      if (startTime && isSlotPast(startTime)) {
-        setStartTime("");
-      }
-    }
-  };
   const [seatsRequested, setSeatsRequested] = useState("");
+  const [timeSlots, setTimeSlots] = useState<TimeSlot[]>([]);
+  const [isSlotsLoading, setIsSlotsLoading] = useState(false);
+  const [slotsError, setSlotsError] = useState("");
+
+  useEffect(() => {
+    if (!date || !seatsRequested) {
+      setTimeSlots([]);
+      return;
+    }
+
+    setIsSlotsLoading(true);
+    setSlotsError("");
+    setStartTime("");
+
+    reservationService
+      .getTimeSlots(date, Number(seatsRequested))
+      .then((response) => setTimeSlots(response.data))
+      .catch((err: unknown) => {
+        const message =
+          err instanceof Error ? err.message : "Error al cargar horarios";
+        setSlotsError(message);
+      })
+      .finally(() => setIsSlotsLoading(false));
+  }, [date, seatsRequested]);
   const [tables, setTables] = useState<Table[]>([]);
   const [selectedTable, setSelectedTable] = useState<Table | null>(null);
   const [isLoading, setIsLoading] = useState(false);
@@ -267,27 +228,19 @@ export default function NewReservationPage() {
         })}
       </div>
 
-      {isSettingsLoading && (
-        <div className="mt-6 space-y-4">
-          {[1, 2, 3].map((i) => (
-            <div key={i} className="h-10 animate-pulse rounded-sm bg-zinc-700" />
-          ))}
-        </div>
-      )}
-
-      {settingsError && (
-        <p className="mt-4 rounded-sm bg-red-900/30 p-3 text-sm text-red-400">
-          {settingsError}
-        </p>
-      )}
-
       {error && (
         <p className="mt-4 rounded-sm bg-red-900/30 p-3 text-sm text-red-400">
           {error}
         </p>
       )}
 
-      {!isSettingsLoading && !settingsError && step === 1 && (
+      {slotsError && (
+        <p className="mt-4 rounded-sm bg-red-900/30 p-3 text-sm text-red-400">
+          {slotsError}
+        </p>
+      )}
+
+      {step === 1 && (
         <form
           onSubmit={(e) => {
             e.preventDefault();
@@ -308,37 +261,11 @@ export default function NewReservationPage() {
               min={minDateStr}
               max={maxDateStr}
               value={date}
-              onChange={(e) => handleDateChange(e.target.value)}
+              onChange={(e) => setDate(e.target.value)}
               required
               className="rounded-sm border border-zinc-600 bg-zinc-700 px-3 py-2.5 text-sm text-white outline-none
                 transition-colors duration-200 focus:ring-1 focus:ring-amber-500"
             />
-          </div>
-
-          <div className="flex flex-col gap-1.5">
-            <span className="text-sm font-medium text-zinc-400">Hora</span>
-            {!date ? (
-              <p className="text-sm text-zinc-500">Selecciona una fecha primero</p>
-            ) : availableSlots.length === 0 ? (
-              <p className="text-sm text-zinc-500">No hay horarios disponibles para esta fecha</p>
-            ) : (
-              <div className="grid grid-cols-4 gap-1.5">
-                {availableSlots.map((slot) => (
-                  <button
-                    key={slot}
-                    type="button"
-                    onClick={() => setStartTime(slot)}
-                    className={`cursor-pointer rounded-sm px-2 py-2 text-xs font-medium transition-all duration-200 ${
-                      startTime === slot
-                        ? "bg-amber-500 text-zinc-900 shadow-sm"
-                        : "border border-zinc-700 text-zinc-400 hover:border-zinc-500 hover:text-white"
-                    }`}
-                  >
-                    {slot}
-                  </button>
-                ))}
-              </div>
-            )}
           </div>
 
           <div className="flex flex-col gap-1.5">
@@ -362,6 +289,46 @@ export default function NewReservationPage() {
                 </button>
               ))}
             </div>
+          </div>
+
+          <div className="flex flex-col gap-1.5">
+            <span className="text-sm font-medium text-zinc-400">Hora</span>
+            {!date || !seatsRequested ? (
+              <p className="text-sm text-zinc-500">Selecciona fecha y personas primero</p>
+            ) : isSlotsLoading ? (
+              <div className="grid grid-cols-4 gap-1.5">
+                {Array.from({ length: 8 }).map((_, i) => (
+                  <div key={i} className="h-9 animate-pulse rounded-sm bg-zinc-700" />
+                ))}
+              </div>
+            ) : timeSlots.length === 0 ? (
+              <p className="text-sm text-zinc-500">No hay horarios disponibles para esta fecha</p>
+            ) : (
+              <div className="grid grid-cols-4 gap-1.5">
+                {timeSlots.map((slot) => {
+                  const isBlocked = slot.status === "blocked";
+                  const isSelected = startTime === slot.start_time;
+
+                  return (
+                    <button
+                      key={slot.start_time}
+                      type="button"
+                      disabled={isBlocked}
+                      onClick={() => setStartTime(slot.start_time)}
+                      className={`rounded-sm px-2 py-2 text-xs font-medium transition-all duration-200 ${
+                        isBlocked
+                          ? "border border-zinc-800 bg-zinc-800 text-zinc-600 line-through cursor-not-allowed"
+                          : isSelected
+                            ? "cursor-pointer bg-amber-500 text-zinc-900 shadow-sm"
+                            : "cursor-pointer border border-zinc-700 text-zinc-400 hover:border-zinc-500 hover:text-white"
+                      }`}
+                    >
+                      {slot.start_time}
+                    </button>
+                  );
+                })}
+              </div>
+            )}
           </div>
 
           <button

--- a/src/pages/PaymentPage.tsx
+++ b/src/pages/PaymentPage.tsx
@@ -152,7 +152,7 @@ function CheckoutForm({ reservation }: CheckoutFormProps) {
         <button
           type="submit"
           disabled={isProcessing || !stripe || !elements}
-          className="rounded-sm bg-amber-500 py-2.5 text-sm font-medium tracking-wide text-zinc-900
+          className="cursor-pointer rounded-sm bg-amber-500 py-2.5 text-sm font-medium tracking-wide text-zinc-900
             transition-colors duration-200 hover:bg-amber-400
             disabled:cursor-not-allowed disabled:opacity-50"
         >

--- a/src/pages/PreOrderPage.tsx
+++ b/src/pages/PreOrderPage.tsx
@@ -215,7 +215,7 @@ export default function PreOrderPage() {
           <button
             type="button"
             onClick={() => setOrderError("")}
-            className="text-sm font-medium text-red-400 hover:text-red-300"
+            className="cursor-pointer text-sm font-medium text-red-400 transition-colors duration-200 hover:text-red-300"
           >
             Cerrar
           </button>

--- a/src/pages/__tests__/NewReservationPage.test.tsx
+++ b/src/pages/__tests__/NewReservationPage.test.tsx
@@ -1,16 +1,14 @@
-import { fireEvent, render, screen, waitFor } from "@testing-library/react";
+import { act, fireEvent, render, screen, waitFor } from "@testing-library/react";
 import userEvent from "@testing-library/user-event";
 import { MemoryRouter } from "react-router-dom";
 import NewReservationPage from "../NewReservationPage";
 import * as reservationService from "../../services/reservation.service";
 import * as guestService from "../../services/guest.service";
-import * as settingsService from "../../services/settings.service";
 import { ApiValidationError } from "../../lib/api";
-import type { Table } from "../../types/api";
+import type { Table, TimeSlot } from "../../types/api";
 
 vi.mock("../../services/reservation.service");
 vi.mock("../../services/guest.service");
-vi.mock("../../services/settings.service");
 
 const mockNavigate = vi.fn();
 
@@ -31,6 +29,15 @@ vi.mock("../../context/AuthContext", () => ({
     setSession: vi.fn(),
   }),
 }));
+
+const MOCK_TIME_SLOTS: TimeSlot[] = [
+  { start_time: "13:00", status: "blocked" },
+  { start_time: "13:30", status: "available" },
+  { start_time: "14:00", status: "available" },
+  { start_time: "14:30", status: "blocked" },
+  { start_time: "15:00", status: "available" },
+  { start_time: "19:00", status: "available" },
+];
 
 const MOCK_TABLES: Table[] = [
   {
@@ -54,6 +61,12 @@ const MOCK_TABLES: Table[] = [
     created_at: "2026-01-01",
   },
 ];
+
+function mockTimeSlots(slots: TimeSlot[] = MOCK_TIME_SLOTS) {
+  vi.mocked(reservationService.getTimeSlots).mockResolvedValue({
+    data: slots,
+  });
+}
 
 function mockAvailableTables(tables: Table[] = MOCK_TABLES) {
   vi.mocked(reservationService.getAvailableTables).mockResolvedValue({
@@ -99,36 +112,6 @@ function mockCreateGuestReservation() {
   });
 }
 
-function mockGetPublicSettings() {
-  vi.mocked(settingsService.getPublicSettings).mockResolvedValue({
-    data: {
-      opening_time: "13:00",
-      closing_time: "23:00",
-      time_slot_interval_minutes: "30",
-    },
-  });
-}
-
-async function renderPage() {
-  render(
-    <MemoryRouter>
-      <NewReservationPage />
-    </MemoryRouter>,
-  );
-  await waitFor(() => {
-    expect(screen.getByLabelText("Fecha")).toBeInTheDocument();
-  });
-}
-
-async function fillSearchAndSubmit(user: ReturnType<typeof userEvent.setup>) {
-  fireEvent.change(screen.getByLabelText("Fecha"), { target: { value: TEST_DATE } });
-  await user.click(screen.getByRole("button", { name: "19:00" }));
-  await user.click(screen.getByRole("button", { name: "3-4" }));
-  await user.click(
-    screen.getByRole("button", { name: "Buscar mesas disponibles" }),
-  );
-}
-
 function futureDate(): string {
   const d = new Date();
   d.setDate(d.getDate() + 2);
@@ -140,36 +123,118 @@ function futureDate(): string {
 
 const TEST_DATE = futureDate();
 
+function renderPage() {
+  render(
+    <MemoryRouter>
+      <NewReservationPage />
+    </MemoryRouter>,
+  );
+}
+
+async function selectDateAndSeats(user: ReturnType<typeof userEvent.setup>) {
+  fireEvent.change(screen.getByLabelText("Fecha"), { target: { value: TEST_DATE } });
+  await user.click(screen.getByRole("button", { name: "3-4" }));
+  await waitFor(() => {
+    expect(reservationService.getTimeSlots).toHaveBeenCalledWith(
+      TEST_DATE,
+      4,
+    );
+  });
+}
+
+async function fillSearchAndSubmit(user: ReturnType<typeof userEvent.setup>) {
+  await selectDateAndSeats(user);
+  await waitFor(() => {
+    expect(screen.getByRole("button", { name: "19:00" })).toBeEnabled();
+  });
+  await user.click(screen.getByRole("button", { name: "19:00" }));
+  await user.click(
+    screen.getByRole("button", { name: "Buscar mesas disponibles" }),
+  );
+}
+
 describe("NewReservationPage", () => {
   beforeEach(() => {
     vi.clearAllMocks();
     mockIsAuthenticated = false;
-    mockGetPublicSettings();
+    mockTimeSlots();
   });
 
   describe("Step 1 - Search", () => {
-    it("renders search form with date, time, and seats fields", async () => {
-      await renderPage();
+    it("renders search form with date, seats, and time fields", () => {
+      renderPage();
 
       expect(screen.getByLabelText("Fecha")).toBeInTheDocument();
-      expect(screen.getByText("Hora")).toBeInTheDocument();
       expect(screen.getByText("Personas")).toBeInTheDocument();
+      expect(screen.getByText("Hora")).toBeInTheDocument();
       expect(
         screen.getByRole("button", { name: "Buscar mesas disponibles" }),
       ).toBeInTheDocument();
     });
 
-    it("renders step indicators", async () => {
-      await renderPage();
+    it("renders step indicators", () => {
+      renderPage();
 
       expect(screen.getByText("Buscar")).toBeInTheDocument();
       expect(screen.getByText("Elegir mesa")).toBeInTheDocument();
       expect(screen.getByText("Confirmar")).toBeInTheDocument();
     });
 
+    it("shows placeholder until date and seats are selected", () => {
+      renderPage();
+
+      expect(
+        screen.getByText("Selecciona fecha y personas primero"),
+      ).toBeInTheDocument();
+    });
+
+    it("fetches time slots when date and seats are selected", async () => {
+      renderPage();
+      const user = userEvent.setup();
+
+      await selectDateAndSeats(user);
+
+      await waitFor(() => {
+        expect(screen.getByRole("button", { name: "19:00" })).toBeEnabled();
+      });
+    });
+
+    it("renders blocked slots as disabled", async () => {
+      renderPage();
+      const user = userEvent.setup();
+
+      await selectDateAndSeats(user);
+
+      await waitFor(() => {
+        expect(screen.getByRole("button", { name: "13:00" })).toBeDisabled();
+        expect(screen.getByRole("button", { name: "14:30" })).toBeDisabled();
+        expect(screen.getByRole("button", { name: "13:30" })).toBeEnabled();
+      });
+    });
+
+    it("shows loading skeletons while fetching slots", async () => {
+      let resolveSlots!: (value: { data: TimeSlot[] }) => void;
+      vi.mocked(reservationService.getTimeSlots).mockReturnValue(
+        new Promise((resolve) => { resolveSlots = resolve; }),
+      );
+      renderPage();
+      const user = userEvent.setup();
+
+      fireEvent.change(screen.getByLabelText("Fecha"), { target: { value: TEST_DATE } });
+      await user.click(screen.getByRole("button", { name: "3-4" }));
+
+      await waitFor(() => {
+        expect(document.querySelectorAll(".animate-pulse").length).toBeGreaterThan(0);
+      });
+
+      await act(async () => {
+        resolveSlots({ data: MOCK_TIME_SLOTS });
+      });
+    });
+
     it("calls getAvailableTables and moves to step 2", async () => {
       mockAvailableTables();
-      await renderPage();
+      renderPage();
       const user = userEvent.setup();
 
       await fillSearchAndSubmit(user);
@@ -190,7 +255,7 @@ describe("NewReservationPage", () => {
 
     it("shows error when no tables are available", async () => {
       mockAvailableTables([]);
-      await renderPage();
+      renderPage();
       const user = userEvent.setup();
 
       await fillSearchAndSubmit(user);
@@ -204,11 +269,11 @@ describe("NewReservationPage", () => {
       });
     });
 
-    it("shows error when API call fails", async () => {
+    it("shows error when getAvailableTables fails", async () => {
       vi.mocked(reservationService.getAvailableTables).mockRejectedValue(
         new Error("Error del servidor"),
       );
-      await renderPage();
+      renderPage();
       const user = userEvent.setup();
 
       await fillSearchAndSubmit(user);
@@ -217,12 +282,53 @@ describe("NewReservationPage", () => {
         expect(screen.getByText("Error del servidor")).toBeInTheDocument();
       });
     });
+
+    it("shows error when getTimeSlots fails", async () => {
+      vi.mocked(reservationService.getTimeSlots).mockRejectedValue(
+        new Error("Error al cargar horarios"),
+      );
+      renderPage();
+      const user = userEvent.setup();
+
+      fireEvent.change(screen.getByLabelText("Fecha"), { target: { value: TEST_DATE } });
+      await user.click(screen.getByRole("button", { name: "3-4" }));
+
+      await waitFor(() => {
+        expect(
+          screen.getByText("Error al cargar horarios"),
+        ).toBeInTheDocument();
+      });
+    });
+
+    it("resets selected time when date changes", async () => {
+      mockAvailableTables();
+      renderPage();
+      const user = userEvent.setup();
+
+      await selectDateAndSeats(user);
+      await waitFor(() => {
+        expect(screen.getByRole("button", { name: "19:00" })).toBeEnabled();
+      });
+      await user.click(screen.getByRole("button", { name: "19:00" }));
+
+      const newDate = new Date();
+      newDate.setDate(newDate.getDate() + 3);
+      const newDateStr = `${newDate.getFullYear()}-${String(newDate.getMonth() + 1).padStart(2, "0")}-${String(newDate.getDate()).padStart(2, "0")}`;
+      fireEvent.change(screen.getByLabelText("Fecha"), { target: { value: newDateStr } });
+
+      await waitFor(() => {
+        expect(reservationService.getTimeSlots).toHaveBeenCalledWith(
+          newDateStr,
+          4,
+        );
+      });
+    });
   });
 
   describe("Step 2 - Table selection", () => {
     async function goToStep2() {
       mockAvailableTables();
-      await renderPage();
+      renderPage();
       const user = userEvent.setup();
       await fillSearchAndSubmit(user);
       await waitFor(() => {
@@ -272,7 +378,7 @@ describe("NewReservationPage", () => {
     async function goToStep3Registered() {
       mockIsAuthenticated = true;
       mockAvailableTables();
-      await renderPage();
+      renderPage();
       const user = userEvent.setup();
 
       await fillSearchAndSubmit(user);
@@ -339,7 +445,7 @@ describe("NewReservationPage", () => {
     async function goToStep3Guest() {
       mockIsAuthenticated = false;
       mockAvailableTables();
-      await renderPage();
+      renderPage();
       const user = userEvent.setup();
 
       await fillSearchAndSubmit(user);

--- a/src/services/reservation.service.ts
+++ b/src/services/reservation.service.ts
@@ -4,6 +4,7 @@ import type {
   PaginatedResponse,
   Reservation,
   Table,
+  TimeSlot,
 } from "../types/api";
 
 interface HoldReservationBody {
@@ -22,6 +23,16 @@ interface AvailableTablesParams {
   date: string;
   start_time: string;
   seats_requested: number;
+}
+
+export function getTimeSlots(date: string, seatsRequested: number) {
+  const query = new URLSearchParams({
+    date,
+    seats_requested: String(seatsRequested),
+  });
+  return apiFetch<ApiResponse<TimeSlot[]>>(
+    `/reservations/time-slots?${query}`,
+  );
 }
 
 export function getAvailableTables(params: AvailableTablesParams) {

--- a/src/types/api.ts
+++ b/src/types/api.ts
@@ -80,6 +80,14 @@ export interface PublicSettings {
   opening_time: string;
   closing_time: string;
   time_slot_interval_minutes: string;
+  default_reservation_duration_minutes: string;
+}
+
+export type TimeSlotStatus = "available" | "blocked";
+
+export interface TimeSlot {
+  start_time: string;
+  status: TimeSlotStatus;
 }
 
 // --- API response wrappers ---


### PR DESCRIPTION
## Summary
- Replace local time slot calculation with the backend `/reservations/time-slots` endpoint, rendering each slot with its `available` / `blocked` status
- Disable the "Buscar mesas" submit until date, time and seats are all selected (removes the misleading post-click error)
- Add `cursor-pointer` and transitions to interactive buttons across auth forms, reservation flow, pre-order, payment and cancellation modal

## Test plan
- [x] 94 unit tests pass (`npx vitest run`)
- [ ] Time slots load dynamically when date + seats are selected
- [ ] Blocked slots render with strikethrough and cannot be clicked
- [ ] Submit button stays disabled until all criteria are set
- [ ] Cursor pointer appears on hover over every interactive button in login, register, forgot/reset password, reservation flow, payment, pre-order and cancel modal

Closes #22