### PR TITLE
Load featured menu items in Destacados tab

### DIFF
--- a/src/pages/MenuPage.tsx
+++ b/src/pages/MenuPage.tsx
@@ -11,8 +11,6 @@ const CATEGORIES: { value: MenuCategory; label: string }[] = [
   { value: "bebidas", label: "Bebidas" },
 ];
 
-const FEATURED_COUNT = 2;
-
 export default function MenuPage() {
   const [items, setItems] = useState<MenuItem[]>([]);
   const [activeCategory, setActiveCategory] = useState<MenuCategory | null>(
@@ -22,13 +20,16 @@ export default function MenuPage() {
   const [error, setError] = useState("");
   const toast = useToast();
 
+  const isFeatured = !activeCategory;
+
   useEffect(() => {
     setIsLoading(true);
     setError("");
 
-    const category = activeCategory ?? undefined;
     menuService
-      .getMenuItems(category)
+      .getMenuItems(
+        isFeatured ? { featured: true } : { category: activeCategory! },
+      )
       .then((response) => setItems(response.data))
       .catch((err: unknown) => {
         const message =
@@ -37,7 +38,7 @@ export default function MenuPage() {
         toast.error(message);
       })
       .finally(() => setIsLoading(false));
-  }, [activeCategory]);
+  }, [activeCategory, isFeatured]);
 
   const groupedItems = activeCategory
     ? { [activeCategory]: items }
@@ -47,8 +48,6 @@ export default function MenuPage() {
         acc[item.category] = group;
         return acc;
       }, {});
-
-  const isFeatured = !activeCategory;
 
   function renderMenuItem(item: MenuItem) {
     return (
@@ -138,10 +137,6 @@ export default function MenuPage() {
           <div className="space-y-12">
             {CATEGORIES.filter((cat) => groupedItems[cat.value]).map((cat) => {
               const categoryItems = groupedItems[cat.value];
-              const visibleItems = isFeatured
-                ? categoryItems.slice(0, FEATURED_COUNT)
-                : categoryItems;
-              const hasMore = isFeatured && categoryItems.length > FEATURED_COUNT;
 
               return (
                 <section key={cat.value}>
@@ -154,10 +149,10 @@ export default function MenuPage() {
                   </div>
 
                   <div className="mt-5 space-y-1">
-                    {visibleItems.map(renderMenuItem)}
+                    {categoryItems.map(renderMenuItem)}
                   </div>
 
-                  {hasMore && (
+                  {isFeatured && (
                     <button
                       type="button"
                       onClick={() => setActiveCategory(cat.value)}

--- a/src/pages/PreOrderPage.tsx
+++ b/src/pages/PreOrderPage.tsx
@@ -90,7 +90,7 @@ export default function PreOrderPage() {
 
     const category = activeCategory ?? undefined;
     menuService
-      .getMenuItems(category)
+      .getMenuItems({ category })
       .then((response) => setMenuItems(response.data))
       .catch((err: unknown) => {
         const message =

--- a/src/pages/__tests__/MenuPage.test.tsx
+++ b/src/pages/__tests__/MenuPage.test.tsx
@@ -119,11 +119,11 @@ describe("MenuPage", () => {
     await user.click(screen.getByRole("button", { name: "Entrantes" }));
 
     await waitFor(() => {
-      expect(menuService.getMenuItems).toHaveBeenLastCalledWith("entrantes");
+      expect(menuService.getMenuItems).toHaveBeenLastCalledWith({ category: "entrantes" });
     });
   });
 
-  it("shows all items when Todos tab is clicked after filtering", async () => {
+  it("refetches featured items when Destacados tab is clicked after filtering", async () => {
     mockGetMenuItems();
     render(<MenuPage />);
     const user = userEvent.setup();
@@ -136,14 +136,14 @@ describe("MenuPage", () => {
     await user.click(screen.getByRole("button", { name: "Entrantes" }));
 
     await waitFor(() => {
-      expect(menuService.getMenuItems).toHaveBeenLastCalledWith("entrantes");
+      expect(menuService.getMenuItems).toHaveBeenLastCalledWith({ category: "entrantes" });
     });
 
     mockGetMenuItems();
     await user.click(screen.getByRole("button", { name: "Destacados" }));
 
     await waitFor(() => {
-      expect(menuService.getMenuItems).toHaveBeenLastCalledWith(undefined);
+      expect(menuService.getMenuItems).toHaveBeenLastCalledWith({ featured: true });
     });
   });
 

--- a/src/pages/__tests__/PreOrderPage.test.tsx
+++ b/src/pages/__tests__/PreOrderPage.test.tsx
@@ -209,7 +209,7 @@ describe("PreOrderPage", () => {
     await user.click(screen.getByRole("button", { name: "Entrantes" }));
 
     await waitFor(() => {
-      expect(menuService.getMenuItems).toHaveBeenCalledWith("entrantes");
+      expect(menuService.getMenuItems).toHaveBeenCalledWith({ category: "entrantes" });
     });
   });
 

--- a/src/services/menu.service.ts
+++ b/src/services/menu.service.ts
@@ -1,8 +1,16 @@
 import { apiFetch } from "../lib/api";
 import type { MenuItem, MenuCategory, PaginatedResponse } from "../types/api";
 
-export function getMenuItems(category?: MenuCategory) {
-  const params = new URLSearchParams({ per_page: "100" });
+interface GetMenuItemsOptions {
+  category?: MenuCategory;
+  featured?: boolean;
+  perPage?: number;
+}
+
+export function getMenuItems(options: GetMenuItemsOptions = {}) {
+  const { category, featured, perPage = 100 } = options;
+  const params = new URLSearchParams({ per_page: String(perPage) });
   if (category) params.set("category", category);
+  if (featured) params.set("featured", "1");
   return apiFetch<PaginatedResponse<MenuItem>>(`/menu-items?${params}`);
 }

--- a/src/types/api.ts
+++ b/src/types/api.ts
@@ -39,6 +39,7 @@ export interface MenuItem {
   price: string;
   category: MenuCategory;
   is_available: boolean;
+  is_featured: boolean;
   daily_stock: number | null;
   created_at: string;
 }


### PR DESCRIPTION
## Summary
- Add `is_featured: boolean` to the `MenuItem` type
- Refactor `getMenuItems` to take an options object (`category`, `featured`, `perPage`) for forward-compatible filters
- Wire the Menu page "Destacados" tab to request real featured items via `?featured=1`, removing the previous client-side slice of the first N items per category
- Keep the "Ver {category} completo" CTA only in the featured view, so users can jump to the full list of each category

## Test plan
- [x] 94 unit tests pass (`npx vitest run`)
- [x] TypeScript type-check passes (`npx tsc --noEmit`)
- [ ] `/menu` opens on the Destacados tab and shows only items with `is_featured: true`, grouped by category
- [ ] Switching to a category tab fetches that category without the featured flag
- [ ] Clicking a category tab from the featured view shows the full category list
- [ ] Returning to Destacados refetches featured items

Addresses the intent of #24 — surfacing featured items to diners — but in the Menu page instead of the HomePage hero, per product direction.

Closes #24